### PR TITLE
feat(store): add `store solution` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ The `store code` command will store your script as a code entry in ckp
 ckp store code 'echo say hi!' --alias="sayHi" --comment="a script that says hi"
 ```
 
+The `store solution` command will store your script as a solution entry in ckp
+
+```
+ckp store solution 'https://career-ladders.dev/engineering/' --comment="carreer ladders"
+```
+
 #### How to `Push` your scripts to your remote solution repository
 
 The `push` command will be commited and pushed to your remote repoitory

--- a/cmd/store.go
+++ b/cmd/store.go
@@ -26,9 +26,8 @@ func NewStoreCommand(conf config.Config) *cobra.Command {
 	command.AddCommand(NewStoreSolutionCommand(conf))
 
 	//Set flags
-	command.PersistentFlags().StringP("path", "p", "", `ckp store -p <path_to_your_code_or_solution>`)
 	command.PersistentFlags().StringP("comment", "c", "", `ckp store -c <comment>`)
-	command.PersistentFlags().StringP("alias", "a", "", `ckp store -a <alias>`)
+	command.PersistentFlags().StringP("path", "p", "", `ckp store -p <path_to_your_code_or_solution>`)
 
 	return command
 }

--- a/cmd/store_code.go
+++ b/cmd/store_code.go
@@ -36,6 +36,8 @@ func NewStoreCodeCommand(conf config.Config) *cobra.Command {
 		},
 	}
 
+	command.PersistentFlags().StringP("alias", "a", "", `ckp store -a <alias>`)
+
 	return command
 }
 

--- a/cmd/store_code.go
+++ b/cmd/store_code.go
@@ -17,7 +17,7 @@ import (
 //NewStoreCodeCommand stores everything that written after --code or --solution flag
 func NewStoreCodeCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
-		Use:     "code [your_code]",
+		Use:     "code <your_code>",
 		Aliases: []string{"c"},
 		Short:   "store code will store your code",
 		Long: `store code will store your code in your solution repository

--- a/cmd/store_solution.go
+++ b/cmd/store_solution.go
@@ -38,7 +38,7 @@ func NewStoreSolutionCommand(conf config.Config) *cobra.Command {
 func storeSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 	cmd.Flags().Parse(args)
 	flags := cmd.Flags()
-	code := strings.Join(args, " ")
+	solution := strings.Join(args, " ")
 
 	storeFile, err := config.GetStoreFilePath(conf)
 	if err != nil {
@@ -60,7 +60,7 @@ func storeSolutionCommand(cmd *cobra.Command, args []string, conf config.Config)
 		return fmt.Errorf("failed to write to file %s: %s", tempFile, err)
 	}
 
-	script, err := createNewSolutionScriptEntry(code, flags)
+	script, err := createNewSolutionScriptEntry(solution, flags)
 	if err != nil {
 		return fmt.Errorf("failed to create new script entry: %s", err)
 	}
@@ -92,11 +92,11 @@ func storeSolutionCommand(cmd *cobra.Command, args []string, conf config.Config)
 		return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
 	}
 
-	fmt.Fprintln(conf.OutWriter, "Your code was successfully stored!")
+	fmt.Fprintln(conf.OutWriter, "Your solution was successfully stored!")
 	return nil
 }
 
-//createNewSolutionScriptEntry return a new code Script entry
+//createNewSolutionScriptEntry return a new solution entry
 func createNewSolutionScriptEntry(solution string, flags *flag.FlagSet) (store.Script, error) {
 	timeNow := time.Now()
 

--- a/cmd/store_solution.go
+++ b/cmd/store_solution.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/elhmn/ckp/internal/config"
+	"github.com/elhmn/ckp/internal/store"
+	"github.com/spf13/cobra"
+	flag "github.com/spf13/pflag"
+)
+
+//NewStoreSolutionCommand stores everything that written after --solution or --solution flag
+func NewStoreSolutionCommand(conf config.Config) *cobra.Command {
+	command := &cobra.Command{
+		Use:     "solution <your_solution>",
+		Aliases: []string{"s"},
+		Short:   "store solution will store your solution",
+		Long: `store solution will store your solution in your solution repository
+
+	example: ckp store solution 'echo this is my command'
+	Will store 'echo this is my command' as a solution asset in your solution repository
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := storeSolutionCommand(cmd, args, conf); err != nil {
+				fmt.Fprintf(conf.OutWriter, "Error: %s\n", err)
+				return
+			}
+		},
+	}
+
+	return command
+}
+
+func storeSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) error {
+	cmd.Flags().Parse(args)
+	flags := cmd.Flags()
+	code := strings.Join(args, " ")
+
+	storeFile, err := config.GetStoreFilePath(conf)
+	if err != nil {
+		return fmt.Errorf("failed to get the store file path: %s", err)
+	}
+
+	storeData, storeBytes, err := store.LoadStore(storeFile)
+	if err != nil {
+		return fmt.Errorf("failed to laod store: %s", err)
+	}
+
+	tempFile, err := config.GetTempStoreFilePath(conf)
+	if err != nil {
+		return fmt.Errorf("failed to get the store temporary file path: %s", err)
+	}
+
+	//Copy the store file to a temporary destination
+	if err := ioutil.WriteFile(tempFile, storeBytes, 0666); err != nil {
+		return fmt.Errorf("failed to write to file %s: %s", tempFile, err)
+	}
+
+	script, err := createNewSolutionScriptEntry(code, flags)
+	if err != nil {
+		return fmt.Errorf("failed to create new script entry: %s", err)
+	}
+
+	if storeData.EntryAlreadyExist(script.ID) {
+		return fmt.Errorf("An identical record was found in the storage, please try `ckp edit --id %s`", script.ID)
+	}
+
+	//Add new script entry in the `Store` struct
+	storeData.Scripts = append(storeData.Scripts, script)
+
+	//Save the new `Store` struct in the store file
+	if err = storeData.SaveStore(storeFile); err != nil {
+		//if we failed to write the store file then we restore the file to its original content
+		if err1 := ioutil.WriteFile(storeFile, storeBytes, 0666); err1 != nil {
+			return fmt.Errorf("failed to write to file %s: %s", storeFile, err)
+		}
+
+		//Delete the temporary file
+		if err := os.RemoveAll(tempFile); err != nil {
+			return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
+		}
+
+		return fmt.Errorf("failed to write to file %s: %s", storeFile, err)
+	}
+
+	//Delete the temporary file
+	if err := os.RemoveAll(tempFile); err != nil {
+		return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
+	}
+
+	fmt.Fprintln(conf.OutWriter, "Your code was successfully stored!")
+	return nil
+}
+
+//createNewSolutionScriptEntry return a new code Script entry
+func createNewSolutionScriptEntry(solution string, flags *flag.FlagSet) (store.Script, error) {
+	timeNow := time.Now()
+
+	//Get data from flags
+	path, err := flags.GetString("path")
+	if err != nil {
+		return store.Script{}, fmt.Errorf("could not parse `path` flag: %s", err)
+	}
+	comment, err := flags.GetString("comment")
+	if err != nil {
+		return store.Script{}, fmt.Errorf("could not parse `comment` flag: %s", err)
+	}
+
+	//Generate script entry unique id
+	id, err := store.GenereateIdempotentID("", path, comment, "", solution)
+	if err != nil {
+		return store.Script{}, fmt.Errorf("failed to generate idem potent id: %s", err)
+	}
+
+	return store.Script{
+		ID:           id,
+		Comment:      comment,
+		CreationTime: timeNow,
+		UpdateTime:   timeNow,
+		Solution: store.Solution{
+			Content:  solution,
+			FilePath: path,
+		},
+	}, nil
+}

--- a/cmd/store_solution_test.go
+++ b/cmd/store_solution_test.go
@@ -1,0 +1,41 @@
+package cmd_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/elhmn/ckp/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStoreSolutionCommand(t *testing.T) {
+	t.Run("make sure that is runs successfully", func(t *testing.T) {
+		conf := createConfig()
+		setupFolder(conf)
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		commandName := "solution"
+		command := cmd.NewStoreCommand(conf)
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		//Set args
+		command.SetArgs([]string{commandName,
+			"our solution",
+			"--path", "filepath",
+			"--comment", "a_comment",
+		})
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		got := writer.String()
+		exp := "Your code was successfully stored!\n"
+		assert.Equal(t, exp, got)
+
+		deleteFolder(conf)
+	})
+}

--- a/cmd/store_solution_test.go
+++ b/cmd/store_solution_test.go
@@ -33,7 +33,7 @@ func TestStoreSolutionCommand(t *testing.T) {
 		}
 
 		got := writer.String()
-		exp := "Your code was successfully stored!\n"
+		exp := "Your solution was successfully stored!\n"
 		assert.Equal(t, exp, got)
 
 		deleteFolder(conf)


### PR DESCRIPTION
#### This pull request implement the `ckp store solution` command

`ckp store solution` takes a text field as argument and create a `solution` entry for it in the `~/.ckp/repo/store.yaml` file.

**Usage:**

```sh
$> ckp store solution 'my solution' -c "mon commentaire"
```

a `store.yaml` file content looks similar to this:

```yaml
## File generated by ckp. DO NOT EDIT
##
## author: elhmn

scripts:
- id: 8856af5056f8f6dd4021ef2ad21c0d65d1356ed51201005dff5cea503990eb2f
  creationtime: 2021-05-08T23:26:44.42195+02:00
  updatetime: 2021-05-08T23:26:44.42195+02:00
  comment: mon commentaire
  solution:
    content: my solution
```

Additionally the `store solution` command takes several flags that are used to set:
* `--comment | -c` to add a comment
* `--path | -p` to add a filepath. The filepath flag indicate where the solution text that should be added to the store is located