### PR TITLE
Add list command

### DIFF
--- a/cmd/ckp.go
+++ b/cmd/ckp.go
@@ -15,5 +15,6 @@ func NewCKPCommand(config config.Config) *cobra.Command {
 
 	ckpCommand.AddCommand(NewInitCommand(config))
 	ckpCommand.AddCommand(NewStoreCommand(config))
+	ckpCommand.AddCommand(NewListCommand(config))
 	return ckpCommand
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/elhmn/ckp/internal/config"
+	"github.com/elhmn/ckp/internal/store"
+	"github.com/spf13/cobra"
+)
+
+//NewListCommand stores everything that written after --code or --solution flag
+func NewListCommand(conf config.Config) *cobra.Command {
+	command := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"l"},
+		Short:   "list will display your code snippets and solutions",
+		Long: `list will display the code snippets and solutions you have stored
+
+	example: ckp list
+	Will list both your first 10 code snippets and solutions
+
+	example: ckp list --limit 20
+	Will list both your first 20 code snippets and solutions
+
+	example: ckp list --code
+	Will list your first 10 code snippets only
+
+	example: ckp list --solution
+	Will list your 10 first solutions only
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := listCommand(cmd, args, conf); err != nil {
+				fmt.Fprintf(conf.OutWriter, "Error: %s\n", err)
+				return
+			}
+		},
+	}
+
+	command.PersistentFlags().Int64P("limit", "l", 10, `ckp list --limit 20`)
+	command.PersistentFlags().BoolP("code", "c", false, `ckp list --code`)
+	command.PersistentFlags().BoolP("solution", "s", false, `ckp list --solution`)
+
+	return command
+}
+
+func listCommand(cmd *cobra.Command, args []string, conf config.Config) error {
+	cmd.Flags().Parse(args)
+	flags := cmd.Flags()
+
+	//Get data from flags
+	limit, err := flags.GetInt64("limit")
+	if err != nil {
+		return fmt.Errorf("could not parse `limit` flag: %s", err)
+	}
+	code, err := flags.GetBool("code")
+	if err != nil {
+		return fmt.Errorf("could not parse `code` flag: %s", err)
+	}
+	solution, err := flags.GetBool("solution")
+	if err != nil {
+		return fmt.Errorf("could not parse `solution` flag: %s", err)
+	}
+
+	//get store data
+	storeFile, err := config.GetStoreFilePath(conf)
+	if err != nil {
+		return fmt.Errorf("failed to get the store file path: %s", err)
+	}
+
+	storeData, _, err := store.LoadStore(storeFile)
+	if err != nil {
+		return fmt.Errorf("failed to laod store: %s", err)
+	}
+
+	list := listScripts(storeData.Scripts, code, solution, limit)
+
+	fmt.Fprintln(conf.OutWriter, list)
+	return nil
+}
+
+func listScripts(scripts []store.Script, isCode, isSolution bool, limit int64) string {
+	list := ""
+	for _, s := range scripts {
+		list += fmt.Sprintf("ID: %s\n", s.ID)
+		list += fmt.Sprintf("CreationTime: %s\n", s.CreationTime.Format(time.RFC1123))
+		list += fmt.Sprintf("UpdateTime: %s\n", s.UpdateTime.Format(time.RFC1123))
+
+		//if the script is a solution
+		if s.Solution.Content != "" || s.Solution.FilePath != "" {
+			list += fmt.Sprintf("  Type: Solution\n")
+			list += fmt.Sprintf("  Comment: %s\n", s.Comment)
+			list += fmt.Sprintf("  Solution: %s\n", s.Solution.Content)
+
+			if s.Solution.FilePath != "" {
+				list += fmt.Sprintf("  FilePath: %s\n", s.Solution.FilePath)
+			}
+		} else {
+			list += fmt.Sprintf("  Type: Code\n")
+			list += fmt.Sprintf("  Alias: %s\n", s.Code.Alias)
+			list += fmt.Sprintf("  Comment: %s\n", s.Comment)
+			list += fmt.Sprintf("  Code: %s\n", s.Code.Content)
+
+			if s.Code.FilePath != "" {
+				list += fmt.Sprintf("  FilePath: %s\n", s.Code.FilePath)
+			}
+		}
+		list += "\n"
+	}
+	return list
+}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -82,16 +82,24 @@ func listCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 func listScripts(scripts []store.Script, isCode, isSolution bool, limit int64) string {
 	list := ""
 	for _, s := range scripts {
-		list += fmt.Sprintf("ID: %s\n", s.ID)
-		list += fmt.Sprintf("CreationTime: %s\n", s.CreationTime.Format(time.RFC1123))
-		list += fmt.Sprintf("UpdateTime: %s\n", s.UpdateTime.Format(time.RFC1123))
-
 		//if the script is a solution
 		if s.Solution.Content != "" {
+			if isCode {
+				continue
+			}
+			list += fmt.Sprintf("ID: %s\n", s.ID)
+			list += fmt.Sprintf("CreationTime: %s\n", s.CreationTime.Format(time.RFC1123))
+			list += fmt.Sprintf("UpdateTime: %s\n", s.UpdateTime.Format(time.RFC1123))
 			list += fmt.Sprintf("  Type: Solution\n")
 			list += fmt.Sprintf("  Comment: %s\n", s.Comment)
 			list += fmt.Sprintf("  Solution: %s\n", s.Solution.Content)
 		} else {
+			if isSolution {
+				continue
+			}
+			list += fmt.Sprintf("ID: %s\n", s.ID)
+			list += fmt.Sprintf("CreationTime: %s\n", s.CreationTime.Format(time.RFC1123))
+			list += fmt.Sprintf("UpdateTime: %s\n", s.UpdateTime.Format(time.RFC1123))
 			list += fmt.Sprintf("  Type: Code\n")
 			list += fmt.Sprintf("  Alias: %s\n", s.Code.Alias)
 			list += fmt.Sprintf("  Comment: %s\n", s.Comment)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -87,23 +87,15 @@ func listScripts(scripts []store.Script, isCode, isSolution bool, limit int64) s
 		list += fmt.Sprintf("UpdateTime: %s\n", s.UpdateTime.Format(time.RFC1123))
 
 		//if the script is a solution
-		if s.Solution.Content != "" || s.Solution.FilePath != "" {
+		if s.Solution.Content != "" {
 			list += fmt.Sprintf("  Type: Solution\n")
 			list += fmt.Sprintf("  Comment: %s\n", s.Comment)
 			list += fmt.Sprintf("  Solution: %s\n", s.Solution.Content)
-
-			if s.Solution.FilePath != "" {
-				list += fmt.Sprintf("  FilePath: %s\n", s.Solution.FilePath)
-			}
 		} else {
 			list += fmt.Sprintf("  Type: Code\n")
 			list += fmt.Sprintf("  Alias: %s\n", s.Code.Alias)
 			list += fmt.Sprintf("  Comment: %s\n", s.Comment)
 			list += fmt.Sprintf("  Code: %s\n", s.Code.Content)
-
-			if s.Code.FilePath != "" {
-				list += fmt.Sprintf("  FilePath: %s\n", s.Code.FilePath)
-			}
 		}
 		list += "\n"
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -37,7 +37,7 @@ func NewListCommand(conf config.Config) *cobra.Command {
 		},
 	}
 
-	command.PersistentFlags().Int64P("limit", "l", 10, `ckp list --limit 20`)
+	command.PersistentFlags().IntP("limit", "l", 10, `ckp list --limit 20`)
 	command.PersistentFlags().BoolP("code", "c", false, `ckp list --code`)
 	command.PersistentFlags().BoolP("solution", "s", false, `ckp list --solution`)
 
@@ -49,7 +49,7 @@ func listCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 	flags := cmd.Flags()
 
 	//Get data from flags
-	limit, err := flags.GetInt64("limit")
+	limit, err := flags.GetInt("limit")
 	if err != nil {
 		return fmt.Errorf("could not parse `limit` flag: %s", err)
 	}
@@ -79,33 +79,42 @@ func listCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 	return nil
 }
 
-func listScripts(scripts []store.Script, isCode, isSolution bool, limit int64) string {
+func getField(field, value string) string {
+	if value != "" {
+		return fmt.Sprintf("%s: %s\n", field, value)
+	}
+	return ""
+}
+
+func listScripts(scripts []store.Script, isCode, isSolution bool, limit int) string {
 	list := ""
-	for _, s := range scripts {
+	size := len(scripts)
+
+	for i := 0; i < limit && i < size; i++ {
+		s := scripts[i]
 		//if the script is a solution
 		if s.Solution.Content != "" {
 			if isCode {
 				continue
 			}
-			list += fmt.Sprintf("ID: %s\n", s.ID)
-			list += fmt.Sprintf("CreationTime: %s\n", s.CreationTime.Format(time.RFC1123))
-			list += fmt.Sprintf("UpdateTime: %s\n", s.UpdateTime.Format(time.RFC1123))
+			list += getField("ID", s.ID)
+			list += getField("CreationTime", s.CreationTime.Format(time.RFC1123))
+			list += getField("UpdateTime", s.UpdateTime.Format(time.RFC1123))
 			list += fmt.Sprintf("  Type: Solution\n")
-			list += fmt.Sprintf("  Comment: %s\n", s.Comment)
-			list += fmt.Sprintf("  Solution: %s\n", s.Solution.Content)
+			list += getField("  Comment", s.Comment)
+			list += getField("  Solution", s.Solution.Content)
 		} else {
 			if isSolution {
 				continue
 			}
-			list += fmt.Sprintf("ID: %s\n", s.ID)
-			list += fmt.Sprintf("CreationTime: %s\n", s.CreationTime.Format(time.RFC1123))
-			list += fmt.Sprintf("UpdateTime: %s\n", s.UpdateTime.Format(time.RFC1123))
+			list += getField("ID", s.ID)
+			list += getField("CreationTime", s.CreationTime.Format(time.RFC1123))
+			list += getField("UpdateTime", s.UpdateTime.Format(time.RFC1123))
 			list += fmt.Sprintf("  Type: Code\n")
-			list += fmt.Sprintf("  Alias: %s\n", s.Code.Alias)
-			list += fmt.Sprintf("  Comment: %s\n", s.Comment)
-			list += fmt.Sprintf("  Code: %s\n", s.Code.Content)
+			list += getField("  Alias", s.Code.Alias)
+			list += getField("  Comment", s.Comment)
+			list += getField("  Code", s.Code.Content)
 		}
-		list += "\n"
 	}
 	return list
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -115,6 +115,7 @@ func listScripts(scripts []store.Script, isCode, isSolution bool, limit int) str
 			list += getField("  Comment", s.Comment)
 			list += getField("  Code", s.Code.Content)
 		}
+		list += "\n"
 	}
 	return list
 }

--- a/cmd/list_internal_test.go
+++ b/cmd/list_internal_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/elhmn/ckp/fixtures"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListScripts(t *testing.T) {
+	list := fixtures.GetListWithMoreThan10Elements()
+
+	t.Run("Returns 11 elements", func(t *testing.T) {
+		got := listScripts(list, false, false, len(list))
+		exp := fixtures.GetPrintListWithMoreThan10Elements()
+		assert.Equal(t, exp, got)
+	})
+
+	t.Run("Returns 2 elements with limit of 2", func(t *testing.T) {
+		got := listScripts(list, false, false, 2)
+		exp := fixtures.GetPrintListWithLessThan2Elements()
+		assert.Equal(t, exp, got)
+	})
+
+	t.Run("Returns only elements of type code", func(t *testing.T) {
+		got := listScripts(list, true, false, len(list))
+		exp := fixtures.GetPrintListOnlyCode()
+		assert.Equal(t, exp, got)
+	})
+
+	t.Run("Returns only elements of type solution", func(t *testing.T) {
+		got := listScripts(list, false, true, len(list))
+		exp := fixtures.GetPrintListOnlySolution()
+		assert.Equal(t, exp, got)
+	})
+}

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,0 +1,31 @@
+package cmd_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/elhmn/ckp/cmd"
+)
+
+func TestListCommand(t *testing.T) {
+	t.Run("make sure that is runs successfully with limit 12", func(t *testing.T) {
+		conf := createConfig()
+		setupFolder(conf)
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		command := cmd.NewListCommand(conf)
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		//Set args
+		command.SetArgs([]string{"-l", "12"})
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		deleteFolder(conf)
+	})
+}

--- a/cmd/store_code.go
+++ b/cmd/store_code.go
@@ -132,9 +132,8 @@ func createNewCodeScriptEntry(code string, flags *flag.FlagSet) (store.Script, e
 		CreationTime: timeNow,
 		UpdateTime:   timeNow,
 		Code: store.Code{
-			Content:  code,
-			Alias:    alias,
-			FilePath: path,
+			Content: code,
+			Alias:   alias,
 		},
 	}, nil
 }

--- a/cmd/store_solution.go
+++ b/cmd/store_solution.go
@@ -122,8 +122,7 @@ func createNewSolutionScriptEntry(solution string, flags *flag.FlagSet) (store.S
 		CreationTime: timeNow,
 		UpdateTime:   timeNow,
 		Solution: store.Solution{
-			Content:  solution,
-			FilePath: path,
+			Content: solution,
 		},
 	}, nil
 }

--- a/fixtures/list.go
+++ b/fixtures/list.go
@@ -1,0 +1,115 @@
+package fixtures
+
+import (
+	"time"
+
+	"github.com/elhmn/ckp/internal/store"
+)
+
+//GetListWithMoreThan10Elements returns list of scripts that contains more than 10 elements
+func GetListWithMoreThan10Elements() []store.Script {
+	creationTimeFix, err := time.Parse(time.RFC1123, "Thu, 13 May 2021 11:36:17 CEST")
+	if err != nil {
+		return nil
+	}
+
+	updateTimeFix, err := time.Parse(time.RFC1123, "Thu, 13 May 2021 11:38:17 CEST")
+	if err != nil {
+		return nil
+	}
+
+	return []store.Script{
+		{ID: "ID_1", CreationTime: creationTimeFix, UpdateTime: updateTimeFix, Comment: "comment_1", Code: store.Code{Content: "code_content_1"}},
+		{ID: "ID_2", CreationTime: creationTimeFix, UpdateTime: updateTimeFix, Comment: "Comment_2", Code: store.Code{Content: "code_content_2", Alias: "Alias_2"}},
+		{ID: "ID_3", CreationTime: creationTimeFix, UpdateTime: updateTimeFix, Code: store.Code{Content: "code_content_3"}},
+		{ID: "ID_4", CreationTime: creationTimeFix, UpdateTime: updateTimeFix, Comment: "Comment_4", Solution: store.Solution{Content: "solution_content_4"}},
+		{ID: "ID_5", CreationTime: creationTimeFix, UpdateTime: updateTimeFix, Solution: store.Solution{Content: "solution_content_5"}},
+	}
+}
+
+func GetPrintListWithMoreThan10Elements() string {
+	return `ID: ID_1
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Code
+  Comment: comment_1
+  Code: code_content_1
+ID: ID_2
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Code
+  Alias: Alias_2
+  Comment: Comment_2
+  Code: code_content_2
+ID: ID_3
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Code
+  Code: code_content_3
+ID: ID_4
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Solution
+  Comment: Comment_4
+  Solution: solution_content_4
+ID: ID_5
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Solution
+  Solution: solution_content_5
+`
+}
+
+func GetPrintListWithLessThan2Elements() string {
+	return `ID: ID_1
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Code
+  Comment: comment_1
+  Code: code_content_1
+ID: ID_2
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Code
+  Alias: Alias_2
+  Comment: Comment_2
+  Code: code_content_2
+`
+}
+
+func GetPrintListOnlyCode() string {
+	return `ID: ID_1
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Code
+  Comment: comment_1
+  Code: code_content_1
+ID: ID_2
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Code
+  Alias: Alias_2
+  Comment: Comment_2
+  Code: code_content_2
+ID: ID_3
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Code
+  Code: code_content_3
+`
+}
+
+func GetPrintListOnlySolution() string {
+	return `ID: ID_4
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Solution
+  Comment: Comment_4
+  Solution: solution_content_4
+ID: ID_5
+CreationTime: Thu, 13 May 2021 11:36:17 CEST
+UpdateTime: Thu, 13 May 2021 11:38:17 CEST
+  Type: Solution
+  Solution: solution_content_5
+`
+}

--- a/fixtures/list.go
+++ b/fixtures/list.go
@@ -34,6 +34,7 @@ UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Type: Code
   Comment: comment_1
   Code: code_content_1
+
 ID: ID_2
 CreationTime: Thu, 13 May 2021 11:36:17 CEST
 UpdateTime: Thu, 13 May 2021 11:38:17 CEST
@@ -41,22 +42,26 @@ UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Alias: Alias_2
   Comment: Comment_2
   Code: code_content_2
+
 ID: ID_3
 CreationTime: Thu, 13 May 2021 11:36:17 CEST
 UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Type: Code
   Code: code_content_3
+
 ID: ID_4
 CreationTime: Thu, 13 May 2021 11:36:17 CEST
 UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Type: Solution
   Comment: Comment_4
   Solution: solution_content_4
+
 ID: ID_5
 CreationTime: Thu, 13 May 2021 11:36:17 CEST
 UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Type: Solution
   Solution: solution_content_5
+
 `
 }
 
@@ -67,6 +72,7 @@ UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Type: Code
   Comment: comment_1
   Code: code_content_1
+
 ID: ID_2
 CreationTime: Thu, 13 May 2021 11:36:17 CEST
 UpdateTime: Thu, 13 May 2021 11:38:17 CEST
@@ -74,6 +80,7 @@ UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Alias: Alias_2
   Comment: Comment_2
   Code: code_content_2
+
 `
 }
 
@@ -84,6 +91,7 @@ UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Type: Code
   Comment: comment_1
   Code: code_content_1
+
 ID: ID_2
 CreationTime: Thu, 13 May 2021 11:36:17 CEST
 UpdateTime: Thu, 13 May 2021 11:38:17 CEST
@@ -91,11 +99,13 @@ UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Alias: Alias_2
   Comment: Comment_2
   Code: code_content_2
+
 ID: ID_3
 CreationTime: Thu, 13 May 2021 11:36:17 CEST
 UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Type: Code
   Code: code_content_3
+
 `
 }
 
@@ -106,10 +116,12 @@ UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Type: Solution
   Comment: Comment_4
   Solution: solution_content_4
+
 ID: ID_5
 CreationTime: Thu, 13 May 2021 11:36:17 CEST
 UpdateTime: Thu, 13 May 2021 11:38:17 CEST
   Type: Solution
   Solution: solution_content_5
+
 `
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -33,16 +33,13 @@ type Script struct {
 }
 
 type Solution struct {
-	Content  string `json:"content,omitempty" yaml:"content,omitempty"`
-	FilePath string `json:"filepath,omitempty" yaml:"filepath,omitempty"`
+	Content string `json:"content,omitempty" yaml:"content,omitempty"`
 }
 
 type Code struct {
 	Content string `json:"content,omitempty" yaml:"content,omitempty"`
 	//Alias is the alias defined for the bash script in the rc file reference
 	Alias string `json:"alias,omitempty" yaml:"alias,omitempty"`
-
-	FilePath string `json:"filepath,omitempty" yaml:"filepath,omitempty"`
 }
 
 //EntryAlreadyExist checks that a script entry of `id` already exist in the store


### PR DESCRIPTION
#### PR to add implement the `ckp list` command

The `list` command implementation contains the following:

- [x] Remove the `FilePath` field from the `Code` and `Solution` objects
- [x] Implement the `list` command with `--limit` flag which defines how many element should be listed
- [x] Implement `--code` flag to list only `code` entries
- [x] Implement `--solution` flag to list only `solution` entries
- [x] Add unit test for the `listScripts` command
- [x] Add basic integration test for the `list` command  