### PR TITLE
feat(find): add find command

### DIFF
--- a/cmd/ckp.go
+++ b/cmd/ckp.go
@@ -16,5 +16,6 @@ func NewCKPCommand(config config.Config) *cobra.Command {
 	ckpCommand.AddCommand(NewInitCommand(config))
 	ckpCommand.AddCommand(NewStoreCommand(config))
 	ckpCommand.AddCommand(NewListCommand(config))
+	ckpCommand.AddCommand(NewFindCommand(config))
 	return ckpCommand
 }

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -49,6 +49,16 @@ func getTemplates() *promptui.SelectTemplates {
 	}
 }
 
+func doesScriptContain(script store.Script, input string) bool {
+	code := strings.Replace(strings.ToLower(script.Code.Content), " ", "", -1)
+	solution := strings.Replace(strings.ToLower(script.Solution.Content), " ", "", -1)
+	comment := strings.Replace(strings.ToLower(script.Comment), " ", "", -1)
+	alias := strings.Replace(strings.ToLower(script.Code.Alias), " ", "", -1)
+	content := fmt.Sprintf("%s %s %s %s", code, solution, comment, alias)
+	input = strings.Replace(strings.ToLower(input), " ", "", -1)
+	return strings.Contains(content, input)
+}
+
 func findCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 	//get store data
 	storeFile, err := config.GetStoreFilePath(conf)
@@ -64,15 +74,7 @@ func findCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 	scripts := storeData.Scripts
 	searchScript := func(input string, index int) bool {
 		s := scripts[index]
-
-		code := strings.Replace(strings.ToLower(s.Code.Content), " ", "", -1)
-		solution := strings.Replace(strings.ToLower(s.Solution.Content), " ", "", -1)
-		comment := strings.Replace(strings.ToLower(s.Comment), " ", "", -1)
-		alias := strings.Replace(strings.ToLower(s.Code.Alias), " ", "", -1)
-		content := fmt.Sprintf("%s %s %s %s", code, solution, comment, alias)
-		input = strings.Replace(strings.ToLower(input), " ", "", -1)
-
-		return strings.Contains(content, input)
+		return doesScriptContain(s, input)
 	}
 
 	prompt := promptui.Select{

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/elhmn/ckp/internal/config"
+	"github.com/elhmn/ckp/internal/store"
+	"github.com/manifoldco/promptui"
+	"github.com/spf13/cobra"
+)
+
+//NewFindCommand display a prompt for you to enter the code or solution you are looking for
+func NewFindCommand(conf config.Config) *cobra.Command {
+	command := &cobra.Command{
+		Use:     "find",
+		Aliases: []string{"f"},
+		Short:   "find your code snippets and solutions",
+		Long: `find your code snippets and solutions
+
+	example: ckp find
+	Will display a prompt for you to enter the code or solution you are looking for
+	`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := findCommand(cmd, args, conf); err != nil {
+				fmt.Fprintf(conf.OutWriter, "Error: %s\n", err)
+				return
+			}
+		},
+	}
+
+	return command
+}
+
+func getTemplates() *promptui.SelectTemplates {
+	//if you find a hard time understand it check out golang templating format documentation
+	//here https://golang.org/pkg/text/template
+	return &promptui.SelectTemplates{
+		Label: "{{ if .Code.Content -}} {{`code:` | bold | green}} " +
+			"{{.Code.Content}} {{- else -}} {{ .Solution.Content }} {{ end }}",
+		Active: "* {{ if .Code.Content -}} {{`code:` | bold | green}} {{.Code.Content | bold}} {{ else }} " +
+			"{{`solution:` | bold | yellow }} {{ .Solution.Content | bold }} {{ end }}",
+		Inactive: "{{ if .Code.Content -}} {{`code:` | green}} {{.Code.Content}} " +
+			"{{- else -}} {{`solution:` | yellow}} {{ .Solution.Content }} {{ end }}",
+		Selected: " {{ `✓` | green }} {{if .Code.Content -}} {{ .Code.Content | bold }} {{- else -}} {{ .Solution.Content | bold }} {{ end }}",
+		Details: "Type: {{- if .Code.Content }} code {{ else }} solution {{- end }}" +
+			"{{ if .Code.Alias }} | Alias: {{ .Code.Alias }} {{- end }}" +
+			"{{ if .Comment }} | Comment: {{ .Comment }} {{- end }}",
+	}
+}
+
+func findCommand(cmd *cobra.Command, args []string, conf config.Config) error {
+	//get store data
+	storeFile, err := config.GetStoreFilePath(conf)
+	if err != nil {
+		return fmt.Errorf("failed to get the store file path: %s", err)
+	}
+
+	storeData, _, err := store.LoadStore(storeFile)
+	if err != nil {
+		return fmt.Errorf("failed to laod store: %s", err)
+	}
+
+	scripts := storeData.Scripts
+	searchScript := func(input string, index int) bool {
+		s := scripts[index]
+
+		code := strings.Replace(strings.ToLower(s.Code.Content), " ", "", -1)
+		solution := strings.Replace(strings.ToLower(s.Solution.Content), " ", "", -1)
+		comment := strings.Replace(strings.ToLower(s.Comment), " ", "", -1)
+		alias := strings.Replace(strings.ToLower(s.Code.Alias), " ", "", -1)
+		content := fmt.Sprintf("%s %s %s %s", code, solution, comment, alias)
+		input = strings.Replace(strings.ToLower(input), " ", "", -1)
+
+		return strings.Contains(content, input)
+	}
+
+	prompt := promptui.Select{
+		Label:             "Enter your search text",
+		Items:             scripts,
+		Size:              5,
+		StartInSearchMode: true,
+		Searcher:          searchScript,
+		Templates:         getTemplates(),
+	}
+
+	_, result, err := prompt.Run()
+	if err != nil {
+		return fmt.Errorf("prompt failed %v", err)
+	}
+
+	fmt.Fprintf(conf.OutWriter, "\n%s", result)
+	return nil
+}

--- a/cmd/find_internal_test.go
+++ b/cmd/find_internal_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/elhmn/ckp/internal/store"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDoesScriptContain(t *testing.T) {
+	tests := []struct {
+		Input string
+		S     store.Script
+		Exp   bool
+	}{
+		{Input: "solution", Exp: true, S: store.Script{
+			Comment:  "my comment",
+			Code:     store.Code{Content: "je suis con", Alias: "mon alias"},
+			Solution: store.Solution{Content: "ma solution"},
+		},
+		},
+		{Input: "comment", Exp: true, S: store.Script{
+			Comment:  "my comment",
+			Code:     store.Code{Content: "je suis con", Alias: "mon alias"},
+			Solution: store.Solution{Content: "ma solution"},
+		},
+		},
+		{Input: "je suis", Exp: true, S: store.Script{
+			Comment:  "my comment",
+			Code:     store.Code{Content: "je suis con", Alias: "mon alias"},
+			Solution: store.Solution{Content: "ma solution"},
+		},
+		},
+		{Input: "alias", Exp: true, S: store.Script{
+			Comment:  "my comment",
+			Code:     store.Code{Content: "je suis con", Alias: "mon alias"},
+			Solution: store.Solution{Content: "ma solution"},
+		},
+		},
+		{Input: "comment alias", Exp: false, S: store.Script{
+			Comment:  "my comment",
+			Code:     store.Code{Content: "je suis con", Alias: "mon alias"},
+			Solution: store.Solution{Content: "ma solution"},
+		},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d - test for \"%s\" equal %v", i, test.Input, test.Exp), func(t *testing.T) {
+			assert.Equal(t, doesScriptContain(test.S, test.Input), test.Exp)
+		})
+	}
+}

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -1,0 +1,30 @@
+package cmd_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/elhmn/ckp/cmd"
+)
+
+func TestFindComment(t *testing.T) {
+	t.Run("make sure that is actually implemented", func(t *testing.T) {
+		conf := createConfig()
+
+		//setup temporary folder
+		setupFolder(conf)
+		defer deleteFolder(conf)
+
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+		command := cmd.NewFindCommand(conf)
+
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/briandowns/spinner v1.12.0
+	github.com/manifoldco/promptui v0.8.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,12 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/briandowns/spinner v1.12.0 h1:72O0PzqGJb6G3KgrcIOtL/JAGGZ5ptOMCn9cUHmqsmw=
 github.com/briandowns/spinner v1.12.0/go.mod h1:QOuQk7x+EaDASo80FEXwlwiA+j/PPIcX3FScO+3/ZPQ=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -99,6 +105,8 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
+github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -109,11 +117,16 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a h1:weJVJJRzAJBFRlAiJQROKQs8oC9vOxvm4rZmBBk0ONw=
+github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/manifoldco/promptui v0.8.0 h1:R95mMF+McvXZQ7j1g8ucVZE1gLP3Sv6j9vlF9kyRqQo=
+github.com/manifoldco/promptui v0.8.0/go.mod h1:n4zTdgP0vr0S3w7/O/g98U+e0gwLScEXGwov2nIKuGQ=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.8 h1:HLtExJ+uU2HOZ+wI0Tt5DtUDrx8yhUqDcp7fYERX4CE=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -232,6 +245,7 @@ golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181026203630-95b1ffbd15a5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,6 +32,35 @@ type Script struct {
 	Code         Code      `json:"code,omitempty" yaml:"code,omitempty"`
 }
 
+func getField(field, value string) string {
+	if value != "" {
+		return fmt.Sprintf("%s: %s\n", field, value)
+	}
+	return ""
+}
+
+func (s Script) String() string {
+	list := ""
+	if s.Solution.Content != "" {
+		list += getField("ID", s.ID)
+		list += getField("CreationTime", s.CreationTime.Format(time.RFC1123))
+		list += getField("UpdateTime", s.UpdateTime.Format(time.RFC1123))
+		list += fmt.Sprintf("  Type: Solution\n")
+		list += getField("  Comment", s.Comment)
+		list += getField("  Solution", s.Solution.Content)
+	} else {
+		list += getField("ID", s.ID)
+		list += getField("CreationTime", s.CreationTime.Format(time.RFC1123))
+		list += getField("UpdateTime", s.UpdateTime.Format(time.RFC1123))
+		list += fmt.Sprintf("  Type: Code\n")
+		list += getField("  Alias", s.Code.Alias)
+		list += getField("  Comment", s.Comment)
+		list += getField("  Code", s.Code.Content)
+	}
+
+	return list
+}
+
 type Solution struct {
 	Content string `json:"content,omitempty" yaml:"content,omitempty"`
 }


### PR DESCRIPTION
#### This PR adds the `ckp find` command

This command loads the `~/.ckp/store.yaml` file and finds the script entry that corresponds to the test provided in the search prompt.

The output looks similar to this:
```sh
Search: yo█
Enter your search text
  *  solution: if you want to write something that makes more sense do this
Type: solution | Comment: here is a new comment
```

And print out this result once you have pressed `Enter` :
```sh
 ✓ if you want to write something that makes more sense do this

ID: 3d833f4d721a805b926532d880bae5b921dd39f766bccbf155251baa01b8432f
CreationTime: Sat, 15 May 2021 10:52:34 CEST
UpdateTime: Sat, 15 May 2021 10:52:34 CEST
  Type: Solution
  Comment: here is a new comment
  Solution: if you want to write something that makes more sense do this
```