### PR TITLE
Add ckp add history command

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -24,6 +24,7 @@ func NewAddCommand(conf config.Config) *cobra.Command {
 	//Add commands
 	command.AddCommand(NewAddCodeCommand(conf))
 	command.AddCommand(NewAddSolutionCommand(conf))
+	command.AddCommand(NewAddHistoryCommand(conf))
 
 	//Set flags
 	command.PersistentFlags().StringP("comment", "m", "", `ckp add -m <comment>`)

--- a/cmd/add_history.go
+++ b/cmd/add_history.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/elhmn/ckp/internal/config"
+	"github.com/elhmn/ckp/internal/history"
+	"github.com/elhmn/ckp/internal/store"
+	"github.com/spf13/cobra"
+)
+
+//NewAddHistoryCommand adds everything that written after --code or --solution flag
+func NewAddHistoryCommand(conf config.Config) *cobra.Command {
+	command := &cobra.Command{
+		Use:     "history",
+		Aliases: []string{"h"},
+		Short:   "add history will store code from your shell history",
+		Long: `add history will store code from your shell history
+	it will read your .bash_history and zsh_history files and store
+	every script oneliner as a code entry in your store.yaml file
+
+	example: ckp history
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := addHistoryCommand(cmd, args, conf); err != nil {
+				fmt.Fprintf(conf.OutWriter, "Error: %s\n", err)
+				return
+			}
+		},
+	}
+
+	return command
+}
+
+func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) error {
+	storeFile, storeData, storeBytes, err := loadStore(conf)
+	if err != nil {
+		return fmt.Errorf("failed to load the store: %s", err)
+	}
+
+	tempFile, err := createTempFile(conf, storeBytes)
+	if err != nil {
+		return fmt.Errorf("failed to create tempFile: %s", err)
+	}
+
+	records, err := history.GetHistoryRecords()
+	if err != nil {
+		return fmt.Errorf("failed to get history records: %s", err)
+	}
+
+	for _, record := range records {
+		//Read history file parse its content and store each entry
+		script, err := createNewHistoryScriptEntry(record)
+		if err != nil {
+			fmt.Fprintf(conf.ErrWriter, "failed to create new script entry: %s", err)
+			continue
+		}
+
+		if storeData.EntryAlreadyExist(script.ID) {
+			continue
+		}
+
+		//Add new script entry in the `Store` struct
+		storeData.Scripts = append(storeData.Scripts, script)
+	}
+
+	//Save storeData in store
+	if err := saveStore(storeData, storeBytes, storeFile, tempFile); err != nil {
+		return fmt.Errorf("failed to save store in %s:  %s", storeFile, err)
+	}
+
+	//Delete the temporary file
+	if err := os.RemoveAll(tempFile); err != nil {
+		return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
+	}
+
+	fmt.Fprintln(conf.OutWriter, "Your history was successfully added!")
+	return nil
+}
+
+//createNewHistoryScriptEntry return a new code Script entry
+func createNewHistoryScriptEntry(code string) (store.Script, error) {
+	timeNow := time.Now()
+	//Generate script entry unique id
+	id, err := store.GenereateIdempotentID(code, "", "", "")
+	if err != nil {
+		return store.Script{}, fmt.Errorf("failed to generate idem potent id: %s", err)
+	}
+
+	return store.Script{
+		ID:           id,
+		CreationTime: timeNow,
+		UpdateTime:   timeNow,
+		Code: store.Code{
+			Content: code,
+		},
+	}, nil
+}

--- a/cmd/add_history_test.go
+++ b/cmd/add_history_test.go
@@ -1,0 +1,37 @@
+package cmd_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/elhmn/ckp/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddHistoryCommand(t *testing.T) {
+	t.Run("make sure that is runs successfully", func(t *testing.T) {
+		conf := createConfig()
+		setupFolder(conf)
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		commandName := "history"
+		command := cmd.NewAddCommand(conf)
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		//Set args
+		command.SetArgs([]string{commandName})
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		got := writer.String()
+		exp := "Your history was successfully added!\n"
+		assert.Equal(t, exp, got)
+
+		deleteFolder(conf)
+	})
+}

--- a/fixtures/history/bash_history_test
+++ b/fixtures/history/bash_history_test
@@ -1,0 +1,6 @@
+exit
+
+echo "je suis con"; echo "tu es con"
+
+pwd
+cd

--- a/fixtures/history/zsh_history_test
+++ b/fixtures/history/zsh_history_test
@@ -1,0 +1,6 @@
+: 1602405531:0;cat /dev/null > ~/.bash_history \
+
+: 1602405534:0;history
+: 1602405620:0;echo "je suis con"; echo "tu es con"
+
+: 1602406506:0;echo "je suis con end of line"

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -1,0 +1,86 @@
+package history
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+const (
+	BashHistoryFile = ".bash_history"
+	ZshHistoryFile  = ".zsh_history"
+)
+
+//GetHistoryRecords returns a list of code records
+//found in your history files
+func GetHistoryRecords() ([]string, error) {
+	records := []string{}
+
+	// 	Get bash history records
+	bashRecords, err := getBashHistoryRecords()
+	if err != nil {
+		return nil, err
+	}
+	records = append(records, bashRecords...)
+
+	//Get zsh history records
+	zshRecords, err := getZshHistoryRecords()
+	if err != nil {
+		return nil, err
+	}
+
+	records = append(records, zshRecords...)
+	return records, nil
+}
+
+func getBashHistoryRecords() ([]string, error) {
+	data, err := readFileData(BashHistoryFile)
+	if err != nil {
+		return nil, err
+	}
+
+	records := strings.Split(data, "\n")
+	return records, nil
+}
+
+func getZshHistoryRecords() ([]string, error) {
+	data, err := readFileData(ZshHistoryFile)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := strings.Split(data, "\n")
+	records := []string{}
+	for _, l := range lines {
+		recordStartIndex := strings.Index(l, ";")
+		if recordStartIndex < 0 {
+			continue
+		}
+
+		line := l[recordStartIndex+1:]
+		records = append(records, line)
+	}
+	return records, nil
+}
+
+func readFileData(filepath string) (string, error) {
+	home, err := homedir.Dir()
+	if err != nil {
+		return "", fmt.Errorf("failed to read home directory: %s", err)
+	}
+	filepath = fmt.Sprintf("%s/%s", home, filepath)
+
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		return "", nil
+	}
+
+	data, err := ioutil.ReadFile(filepath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file %s: %s", filepath, err)
+	}
+
+	return string(data), nil
+}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 )
 
-const (
+var (
 	BashHistoryFile = ".bash_history"
 	ZshHistoryFile  = ".zsh_history"
 )
@@ -42,7 +42,11 @@ func getBashHistoryRecords() ([]string, error) {
 		return nil, err
 	}
 
-	records := strings.Split(data, "\n")
+	f := func(c rune) bool {
+		return c == '\n'
+	}
+
+	records := strings.FieldsFunc(data, f)
 	return records, nil
 }
 
@@ -52,7 +56,10 @@ func getZshHistoryRecords() ([]string, error) {
 		return nil, err
 	}
 
-	lines := strings.Split(data, "\n")
+	f := func(c rune) bool {
+		return c == '\n'
+	}
+	lines := strings.FieldsFunc(data, f)
 	records := []string{}
 	for _, l := range lines {
 		recordStartIndex := strings.Index(l, ";")

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -1,0 +1,84 @@
+package history_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/elhmn/ckp/internal/history"
+	"github.com/mitchellh/go-homedir"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTempFileFromFixture(filepath, fixtureFilePath string) error {
+	fixtureData, err := ioutil.ReadFile(fixtureFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s data: %s", fixtureFilePath, err)
+	}
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return fmt.Errorf("failed to read home directory: %s", err)
+	}
+	filepath = fmt.Sprintf("%s/%s", home, filepath)
+
+	//Copy the store file to a temporary destination
+	if err := ioutil.WriteFile(filepath, fixtureData, 0666); err != nil {
+		return fmt.Errorf("failed to write to file %s: %s", filepath, err)
+	}
+
+	return nil
+}
+
+func deleteFile(filepath string) error {
+	home, err := homedir.Dir()
+	if err != nil {
+		return fmt.Errorf("failed to read home directory: %s", err)
+	}
+
+	return os.Remove(fmt.Sprintf("%s/%s", home, filepath))
+}
+
+func TestGetHistoryRecords(t *testing.T) {
+	//set history files to fixtures
+	origBashHistoryFile := history.BashHistoryFile
+	origZshHistoryFile := history.ZshHistoryFile
+	history.BashHistoryFile = "bash_history_test"
+	history.ZshHistoryFile = "zsh_history_test"
+
+	err := createTempFileFromFixture(history.BashHistoryFile, "../../fixtures/history/bash_history_test")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = createTempFileFromFixture(history.ZshHistoryFile, "../../fixtures/history/zsh_history_test")
+	if err != nil {
+		t.Error(err)
+	}
+
+	t.Run("return history records", func(t *testing.T) {
+		exp := []string{
+			"exit",
+			"echo \"je suis con\"; echo \"tu es con\"",
+			"pwd",
+			"cd",
+			"cat /dev/null > ~/.bash_history \\",
+			"history",
+			"echo \"je suis con\"; echo \"tu es con\"",
+			"echo \"je suis con end of line\"",
+		}
+		records, err := history.GetHistoryRecords()
+		if err != nil {
+			t.Error(err)
+		}
+		assert.Equal(t, exp, records)
+	})
+
+	//Delete history tmp files
+	deleteFile(history.BashHistoryFile)
+	deleteFile(history.ZshHistoryFile)
+	//Restore history path
+	history.BashHistoryFile = origBashHistoryFile
+	history.ZshHistoryFile = origZshHistoryFile
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -120,8 +120,8 @@ func LoadStore(filepath string) (*Store, []byte, error) {
 }
 
 //GenereateIdempotentID generate a unique sha256
-func GenereateIdempotentID(code, path, comment, alias, solution string) (string, error) {
-	id := []byte(fmt.Sprintf("%s-%s-%s-%s-%s", code, path, comment, alias, solution))
+func GenereateIdempotentID(code, comment, alias, solution string) (string, error) {
+	id := []byte(fmt.Sprintf("%s-%s-%s-%s", code, comment, alias, solution))
 	hash := sha256.New()
 	if _, err := hash.Write(id); err != nil {
 		return "", err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9,14 +9,14 @@ import (
 
 func TestGenerateIdempotentID(t *testing.T) {
 	t.Run("returns the same hash for similar content", func(t *testing.T) {
-		id1, _ := store.GenereateIdempotentID("code", "path", "comment", "alias", "solution")
-		id2, _ := store.GenereateIdempotentID("code", "path", "comment", "alias", "solution")
+		id1, _ := store.GenereateIdempotentID("code", "comment", "alias", "solution")
+		id2, _ := store.GenereateIdempotentID("code", "comment", "alias", "solution")
 		assert.Equal(t, id1, id2)
 	})
 
 	t.Run("returns the different hash for different content", func(t *testing.T) {
-		id1, _ := store.GenereateIdempotentID("code", "path", "comment", "alias", "solution")
-		id2, _ := store.GenereateIdempotentID("code1", "path2", "comment3", "alias4", "solution5")
+		id1, _ := store.GenereateIdempotentID("code", "comment", "alias", "solution")
+		id2, _ := store.GenereateIdempotentID("code1", "comment3", "alias4", "solution5")
 		assert.NotEqual(t, id1, id2)
 	})
 }


### PR DESCRIPTION
#### This pull request implements the `ckp add history` command

This command read your `.bash_history` or `.zsh_history` file,  get code entry and store them in your `~/.ckp/repo/store.yaml` file