### PR TITLE
feat(add): synchronise the local store with the remote store before running the add command and push this changes

### DIFF
--- a/cmd/add_history_test.go
+++ b/cmd/add_history_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAddHistoryCommand(t *testing.T) {
 	t.Run("make sure that is runs successfully", func(t *testing.T) {
-		conf := createConfig()
+		conf, _ := createConfig()
 
 		if err := setupFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)

--- a/cmd/add_solution_test.go
+++ b/cmd/add_solution_test.go
@@ -6,11 +6,23 @@ import (
 
 	"github.com/elhmn/ckp/cmd"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestAddSolutionCommand(t *testing.T) {
 	t.Run("make sure that is runs successfully", func(t *testing.T) {
-		conf, _ := createConfig()
+		conf, mockedExec := createConfig()
+
+		//Setup function calls mocks
+		mockedExec.On("DoGit", mock.Anything, "diff").Return(mock.Anything, nil).Once()
+		mockedExec.On("DoGit", mock.Anything, "diff", mock.Anything).Return(mock.Anything, nil).Once()
+		mockedExec.On("DoGit", mock.Anything, "stash").Return(mock.Anything, nil).Once()
+		mockedExec.On("DoGit", mock.Anything, "stash", "apply").Return(mock.Anything, nil).Once()
+		mockedExec.On("DoGit", mock.Anything, "pull", "--rebase", "origin", "master").Return(mock.Anything, nil).Once()
+		mockedExec.On("DoGit", mock.Anything, "add", mock.Anything).Return(mock.Anything, nil).Once()
+		mockedExec.On("DoGit", mock.Anything, "commit", "-m", mock.Anything).Return(mock.Anything, nil).Once()
+		mockedExec.On("DoGitPush", mock.Anything, "origin", "master").Return(mock.Anything, nil).Once()
+
 		if err := setupFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)
 		}
@@ -35,8 +47,9 @@ func TestAddSolutionCommand(t *testing.T) {
 		}
 
 		got := writer.String()
-		exp := "Your solution was successfully added!\n"
+		exp := "\nYour solution was successfully added!\n"
 		assert.Equal(t, exp, got)
+		mockedExec.AssertExpectations(t)
 
 		if err := deleteFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)

--- a/cmd/add_solution_test.go
+++ b/cmd/add_solution_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAddSolutionCommand(t *testing.T) {
 	t.Run("make sure that is runs successfully", func(t *testing.T) {
-		conf := createConfig()
+		conf, _ := createConfig()
 		if err := setupFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)
 		}

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFindComment(t *testing.T) {
 	t.Run("make sure that is actually implemented", func(t *testing.T) {
-		conf := createConfig()
+		conf, _ := createConfig()
 
 		//setup temporary folder
 		if err := setupFolder(conf); err != nil {

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestListCommand(t *testing.T) {
 	t.Run("make sure that is runs successfully with limit 12", func(t *testing.T) {
-		conf := createConfig()
+		conf, _ := createConfig()
 		if err := setupFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)
 		}
@@ -34,7 +34,7 @@ func TestListCommand(t *testing.T) {
 	})
 
 	t.Run("make sure that is runs successfully with --all flag set", func(t *testing.T) {
-		conf := createConfig()
+		conf, _ := createConfig()
 		if err := setupFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)
 		}

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -15,6 +15,8 @@ import (
 func TestPushCommand(t *testing.T) {
 	getMockedExec := func() *mocks.IExec {
 		mockedExec := &mocks.IExec{}
+		mockedExec.On("DoGit", mock.Anything, "diff").Return(mock.Anything, nil).Once()
+		mockedExec.On("DoGit", mock.Anything, "diff", mock.Anything).Return(mock.Anything, nil).Once()
 		mockedExec.On("DoGit", mock.Anything, "stash").Return(mock.Anything, nil).Once()
 		mockedExec.On("DoGit", mock.Anything, "stash", "apply").Return(mock.Anything, nil).Once()
 		mockedExec.On("DoGit", mock.Anything, "pull", "--rebase", "origin", "master").Return(mock.Anything, nil).Once()


### PR DESCRIPTION
#### This pull request is making sure that the local store is always in sync with the remote store

**Why ?**
For every destructive action on the store such as an addition, a removal or an edition we want the store to always be synchronised with the remote changes in order to avoid conflicts. Also to limit the possibility of conflicts between the local and remote store we have decided to push this destructive changes immediately after they have been done.

**How ?**
To perform this task :
- We initially check whether or not we have local changes, if so we stash these changes before pulling the remote store
-  After we have pulled the remote changes we make sure to apply the stash of the local changes we previously made
- Then  we perform the addition as it was done before 
- And Finally we push local changes to the remote store

**Steps to verify:**
1. Build the binary with `make build`
2. Add a new code entry using `./ckp add code "echo my new code entry"`
3. Add a new solution entry using `./ckp solution "echo my new solution entry"`
4. Now go to your store remote url should be something like that `https://github.com/elhmn/solution`
5. Open the `store.yaml` file and check that your new entries where in fact added
