### PR TITLE
Add check for secret in history command

### DIFF
--- a/cmd/add_code.go
+++ b/cmd/add_code.go
@@ -51,7 +51,7 @@ func addCodeCommand(cmd *cobra.Command, args []string, conf config.Config) error
 
 	//Check if the code entry contains sensitive data
 	if ret, word := store.HasSensitiveData(code); ret {
-		fmt.Fprintf(conf.OutWriter, "Contains the keyword `%s` in %s\n", word, code)
+		fmt.Fprintf(conf.OutWriter, "Found the keyword `%s` in %s\n", word, code)
 		if !printers.Confirm("Add anyway ?") {
 			fmt.Fprintf(conf.OutWriter, "Code entry addition was aborted!\n")
 			return nil

--- a/cmd/add_history.go
+++ b/cmd/add_history.go
@@ -51,6 +51,23 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 		return fmt.Errorf("failed to get history records: %s", err)
 	}
 
+	addScriptsFromRecords(conf, records, storeData)
+
+	//Save storeData in store
+	if err := saveStore(storeData, storeBytes, storeFile, tempFile); err != nil {
+		return fmt.Errorf("failed to save store in %s:  %s", storeFile, err)
+	}
+
+	//Delete the temporary file
+	if err := os.RemoveAll(tempFile); err != nil {
+		return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
+	}
+
+	fmt.Fprintln(conf.OutWriter, "Your history was successfully added!")
+	return nil
+}
+
+func addScriptsFromRecords(conf config.Config, records []string, storeData *store.Store) *store.Store {
 	size := len(records)
 	for i, record := range records {
 		//Check if the code entry contains sensitive data
@@ -78,18 +95,7 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 		storeData.Scripts = append(storeData.Scripts, script)
 	}
 
-	//Save storeData in store
-	if err := saveStore(storeData, storeBytes, storeFile, tempFile); err != nil {
-		return fmt.Errorf("failed to save store in %s:  %s", storeFile, err)
-	}
-
-	//Delete the temporary file
-	if err := os.RemoveAll(tempFile); err != nil {
-		return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
-	}
-
-	fmt.Fprintln(conf.OutWriter, "Your history was successfully added!")
-	return nil
+	return storeData
 }
 
 //createNewHistoryScriptEntry return a new code Script entry

--- a/cmd/add_history_test.go
+++ b/cmd/add_history_test.go
@@ -5,12 +5,31 @@ import (
 	"testing"
 
 	"github.com/elhmn/ckp/cmd"
+	"github.com/elhmn/ckp/internal/files"
+	"github.com/elhmn/ckp/internal/history"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAddHistoryCommand(t *testing.T) {
 	t.Run("make sure that is runs successfully", func(t *testing.T) {
 		conf, _ := createConfig()
+		//set history files to fixtures
+		origBashHistoryFile := history.BashHistoryFile
+		origZshHistoryFile := history.ZshHistoryFile
+		history.BashHistoryFile = "bash_history_test"
+		history.ZshHistoryFile = "zsh_history_test"
+
+		//create bash_history fixtures
+		err := files.CopyFileToHomeDirectory(history.BashHistoryFile, "../fixtures/history/bash_history_test")
+		if err != nil {
+			t.Error(err)
+		}
+
+		//create zsh_history fixtures
+		err = files.CopyFileToHomeDirectory(history.ZshHistoryFile, "../fixtures/history/zsh_history_test")
+		if err != nil {
+			t.Error(err)
+		}
 
 		if err := setupFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)
@@ -27,8 +46,7 @@ func TestAddHistoryCommand(t *testing.T) {
 		//Set args
 		command.SetArgs([]string{commandName})
 
-		err := command.Execute()
-		if err != nil {
+		if err := command.Execute(); err != nil {
 			t.Errorf("Error: failed with %s", err)
 		}
 
@@ -39,5 +57,17 @@ func TestAddHistoryCommand(t *testing.T) {
 		if err := deleteFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)
 		}
+
+		//Delete history tmp files
+		if err := files.DeleteFileFromHomeDirectory(history.BashHistoryFile); err != nil {
+			t.Error(err)
+		}
+		if err := files.DeleteFileFromHomeDirectory(history.ZshHistoryFile); err != nil {
+			t.Error(err)
+		}
+
+		//Restore history path
+		history.BashHistoryFile = origBashHistoryFile
+		history.ZshHistoryFile = origZshHistoryFile
 	})
 }

--- a/cmd/add_solution.go
+++ b/cmd/add_solution.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/elhmn/ckp/internal/config"
+	"github.com/elhmn/ckp/internal/printers"
 	"github.com/elhmn/ckp/internal/store"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
@@ -36,16 +37,25 @@ func NewAddSolutionCommand(conf config.Config) *cobra.Command {
 }
 
 func addSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) error {
-	//Setup spinner
-	spin := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-	spin.Start()
-	defer spin.Stop()
-
 	if err := cmd.Flags().Parse(args); err != nil {
 		return err
 	}
 	flags := cmd.Flags()
 	solution := strings.Join(args, " ")
+
+	//Check if the code entry contains sensitive data
+	if ret, word := store.HasSensitiveData(solution); ret {
+		fmt.Fprintf(conf.OutWriter, "Found the keyword `%s` in %s\n", word, solution)
+		if !printers.Confirm("Add anyway ?") {
+			fmt.Fprintf(conf.OutWriter, "Solution entry addition was aborted!\n")
+			return nil
+		}
+	}
+
+	//Setup spinner
+	spin := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
+	spin.Start()
+	defer spin.Stop()
 
 	dir, err := config.GetStoreDirPath(conf)
 	if err != nil {

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -1,44 +1,12 @@
 package history_test
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 
+	"github.com/elhmn/ckp/internal/files"
 	"github.com/elhmn/ckp/internal/history"
-	"github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/assert"
 )
-
-func createTempFileFromFixture(filepath, fixtureFilePath string) error {
-	fixtureData, err := ioutil.ReadFile(fixtureFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to read file %s data: %s", fixtureFilePath, err)
-	}
-
-	home, err := homedir.Dir()
-	if err != nil {
-		return fmt.Errorf("failed to read home directory: %s", err)
-	}
-	filepath = fmt.Sprintf("%s/%s", home, filepath)
-
-	//Copy the store file to a temporary destination
-	if err := ioutil.WriteFile(filepath, fixtureData, 0666); err != nil {
-		return fmt.Errorf("failed to write to file %s: %s", filepath, err)
-	}
-
-	return nil
-}
-
-func deleteFile(filepath string) error {
-	home, err := homedir.Dir()
-	if err != nil {
-		return fmt.Errorf("failed to read home directory: %s", err)
-	}
-
-	return os.Remove(fmt.Sprintf("%s/%s", home, filepath))
-}
 
 func TestGetHistoryRecords(t *testing.T) {
 	//set history files to fixtures
@@ -47,12 +15,14 @@ func TestGetHistoryRecords(t *testing.T) {
 	history.BashHistoryFile = "bash_history_test"
 	history.ZshHistoryFile = "zsh_history_test"
 
-	err := createTempFileFromFixture(history.BashHistoryFile, "../../fixtures/history/bash_history_test")
+	//create bash_history fixtures
+	err := files.CopyFileToHomeDirectory(history.BashHistoryFile, "../../fixtures/history/bash_history_test")
 	if err != nil {
 		t.Error(err)
 	}
 
-	err = createTempFileFromFixture(history.ZshHistoryFile, "../../fixtures/history/zsh_history_test")
+	//create zsh_history fixtures
+	err = files.CopyFileToHomeDirectory(history.ZshHistoryFile, "../../fixtures/history/zsh_history_test")
 	if err != nil {
 		t.Error(err)
 	}
@@ -76,10 +46,10 @@ func TestGetHistoryRecords(t *testing.T) {
 	})
 
 	//Delete history tmp files
-	if err := deleteFile(history.BashHistoryFile); err != nil {
+	if err := files.DeleteFileFromHomeDirectory(history.BashHistoryFile); err != nil {
 		t.Error(err)
 	}
-	if err := deleteFile(history.ZshHistoryFile); err != nil {
+	if err := files.DeleteFileFromHomeDirectory(history.ZshHistoryFile); err != nil {
 		t.Error(err)
 	}
 

--- a/internal/printers/printers.go
+++ b/internal/printers/printers.go
@@ -1,0 +1,36 @@
+package printers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/manifoldco/promptui"
+)
+
+//Confirm prompt a confirmation message
+//
+//Return true if the user entered Y/y and false if entered n/N
+func Confirm(message string) bool {
+	validate := func(input string) error {
+		input = strings.ToLower(strings.TrimSpace(input))
+		if input != "y" && input != "n" {
+			return fmt.Errorf("wrong input %s, was expecting `y` or `n`", input)
+		}
+
+		return nil
+	}
+
+	msg := message + " Press (y/n)"
+	prompt := promptui.Prompt{
+		Label:    msg,
+		Validate: validate,
+	}
+
+	result, err := prompt.Run()
+	if err != nil {
+		return false
+	}
+	input := strings.ToLower(strings.TrimSpace(result))
+
+	return input == "y"
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -22,6 +23,14 @@ const (
 type Store struct {
 	Scripts []Script `json:"scripts,omitempty" yaml:"scripts,omitempty"`
 }
+
+var sensitiveWords = []string{"key",
+	"secret",
+	"auth",
+	"creds",
+	"credential",
+	"token",
+	"barear"}
 
 //Script defines the structure of an entry in the `Store`
 type Script struct {
@@ -128,4 +137,22 @@ func GenereateIdempotentID(code, comment, alias, solution string) (string, error
 		return "", err
 	}
 	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+//HasSensitiveData checks if the `s` contains sensitive data
+//
+//Returns true and the keyword that was found in the string `s`
+//was found
+//Returns false when no keyword was found
+func HasSensitiveData(s string) (bool, string) {
+	s = strings.ToLower(s)
+
+	for _, w := range sensitiveWords {
+		strings.Contains(s, w)
+		if strings.Contains(s, w) {
+			return true, w
+		}
+	}
+
+	return false, ""
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -30,7 +30,7 @@ var sensitiveWords = []string{"key",
 	"creds",
 	"credential",
 	"token",
-	"barear"}
+	"bearer"}
 
 //Script defines the structure of an entry in the `Store`
 type Script struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,6 +1,7 @@
 package store_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/elhmn/ckp/internal/store"
@@ -43,5 +44,140 @@ func TestEntryAlreadyExist(t *testing.T) {
 		}
 
 		assert.Equal(t, false, s.EntryAlreadyExist(nonExistingID))
+	})
+}
+
+func TestHasSensitiveDataExist(t *testing.T) {
+	type Test struct {
+		input   string
+		expBool bool
+		expWord string
+	}
+
+	t.Run("Test for `key` keyword", func(t *testing.T) {
+		tests := []Test{
+			{input: "je suis con", expBool: false, expWord: ""},
+			{input: " je suisK ey con ", expBool: false, expWord: ""},
+			{input: "je suis con key", expBool: true, expWord: "key"},
+			{input: "je suis con Key", expBool: true, expWord: "key"},
+			{input: "KEY je suis con", expBool: true, expWord: "key"},
+			{input: " je suisKey con ", expBool: true, expWord: "key"},
+		}
+
+		for i, test := range tests {
+			t.Run(fmt.Sprintf("%d-test", i), func(t *testing.T) {
+				gotBool, gotWord := store.HasSensitiveData(test.input)
+				assert.Equal(t, test.expBool, gotBool)
+				assert.Equal(t, test.expWord, gotWord)
+			})
+		}
+	})
+
+	t.Run("Test for `secret` keyword", func(t *testing.T) {
+		tests := []Test{
+			{input: " je suisSE CRET con ", expBool: false, expWord: ""},
+			{input: "je suis con secret", expBool: true, expWord: "secret"},
+			{input: "je suis con SECRET", expBool: true, expWord: "secret"},
+			{input: "SECRET je suis con", expBool: true, expWord: "secret"},
+			{input: " je suisSECRET con ", expBool: true, expWord: "secret"},
+		}
+
+		for i, test := range tests {
+			t.Run(fmt.Sprintf("%d-test", i), func(t *testing.T) {
+				gotBool, gotWord := store.HasSensitiveData(test.input)
+				assert.Equal(t, test.expBool, gotBool)
+				assert.Equal(t, test.expWord, gotWord)
+			})
+		}
+	})
+
+	t.Run("Test for `auth` keyword", func(t *testing.T) {
+		tests := []Test{
+			{input: " je suisAU TH con ", expBool: false, expWord: ""},
+			{input: "je suis con auth", expBool: true, expWord: "auth"},
+			{input: "je suis con AUTH", expBool: true, expWord: "auth"},
+			{input: "AUTH je suis con", expBool: true, expWord: "auth"},
+			{input: " je suisAuTh con ", expBool: true, expWord: "auth"},
+		}
+
+		for i, test := range tests {
+			t.Run(fmt.Sprintf("%d-test", i), func(t *testing.T) {
+				gotBool, gotWord := store.HasSensitiveData(test.input)
+				assert.Equal(t, test.expBool, gotBool)
+				assert.Equal(t, test.expWord, gotWord)
+			})
+		}
+	})
+
+	t.Run("Test for `credential` keyword", func(t *testing.T) {
+		tests := []Test{
+			{input: " je suisCR EDENTIAL con ", expBool: false, expWord: ""},
+			{input: "je suis con credential", expBool: true, expWord: "credential"},
+			{input: "je suis con CREDENTIAL", expBool: true, expWord: "credential"},
+			{input: "CREDENTIAL je suis con", expBool: true, expWord: "credential"},
+			{input: " je suisCredEntial con ", expBool: true, expWord: "credential"},
+		}
+
+		for i, test := range tests {
+			t.Run(fmt.Sprintf("%d-test", i), func(t *testing.T) {
+				gotBool, gotWord := store.HasSensitiveData(test.input)
+				assert.Equal(t, test.expBool, gotBool)
+				assert.Equal(t, test.expWord, gotWord)
+			})
+		}
+	})
+
+	t.Run("Test for `creds` keyword", func(t *testing.T) {
+		tests := []Test{
+			{input: " je suisCR EDS con ", expBool: false, expWord: ""},
+			{input: "je suis con creds", expBool: true, expWord: "creds"},
+			{input: "je suis con CREDS", expBool: true, expWord: "creds"},
+			{input: "CREDS je suis con", expBool: true, expWord: "creds"},
+			{input: " je suisCredS con ", expBool: true, expWord: "creds"},
+		}
+
+		for i, test := range tests {
+			t.Run(fmt.Sprintf("%d-test", i), func(t *testing.T) {
+				gotBool, gotWord := store.HasSensitiveData(test.input)
+				assert.Equal(t, test.expBool, gotBool)
+				assert.Equal(t, test.expWord, gotWord)
+			})
+		}
+	})
+
+	t.Run("Test for `token` keyword", func(t *testing.T) {
+		tests := []Test{
+			{input: " je suisTO KEN con ", expBool: false, expWord: ""},
+			{input: "je suis con token", expBool: true, expWord: "token"},
+			{input: "je suis con TOKEN", expBool: true, expWord: "token"},
+			{input: "TOKEN je suis con", expBool: true, expWord: "token"},
+			{input: " je suisTokEn con ", expBool: true, expWord: "token"},
+		}
+
+		for i, test := range tests {
+			t.Run(fmt.Sprintf("%d-test", i), func(t *testing.T) {
+				gotBool, gotWord := store.HasSensitiveData(test.input)
+				assert.Equal(t, test.expBool, gotBool)
+				assert.Equal(t, test.expWord, gotWord)
+			})
+		}
+	})
+
+	t.Run("Test for `bearer` keyword", func(t *testing.T) {
+		tests := []Test{
+			{input: " je suisBEA RER con ", expBool: false, expWord: ""},
+			{input: "je suis con bearer", expBool: true, expWord: "bearer"},
+			{input: "je suis con BEARER", expBool: true, expWord: "bearer"},
+			{input: "BEARER je suis con", expBool: true, expWord: "bearer"},
+			{input: " je suisBeaRer con ", expBool: true, expWord: "bearer"},
+		}
+
+		for i, test := range tests {
+			t.Run(fmt.Sprintf("%d-test", i), func(t *testing.T) {
+				gotBool, gotWord := store.HasSensitiveData(test.input)
+				assert.Equal(t, test.expBool, gotBool)
+				assert.Equal(t, test.expWord, gotWord)
+			})
+		}
 	})
 }


### PR DESCRIPTION
#### This pull request a a confirmation prompt for history records that might leak secrets

**Why ?**
When the `ckp add history` command is run the chances for secrets to be pushed to our remote storage repository increases. And we would like to prevent that from happening

**How ?**
In order to avoid those secrets to leak, we prompt a confirmation dialog for each history record that contains one of the 
following key words:
- key
- secret
- auth
- creds
- credential
- token
- bearer

**Steps to verify:**

1. Run `ckp add code echo "my command key"`
2. Run `ckp add solution echo "my command secret"`
3. Run `ckp add history` this should at least display a prompt for the 2 previous commands