### PR TITLE
Sync local and remote store for add history

### DIFF
--- a/cmd/add_code.go
+++ b/cmd/add_code.go
@@ -120,7 +120,7 @@ func addCodeCommand(cmd *cobra.Command, args []string, conf config.Config) error
 	spin.Suffix = " new entry successfully added"
 
 	spin.Suffix = " pushing local changes..."
-	err = pushLocalChanges(conf, dir, storeFilePath)
+	err = pushLocalChanges(conf, dir, storeFilePath, commitAddAction)
 	if err != nil {
 		return fmt.Errorf("failed to push local changes: %s", err)
 	}

--- a/cmd/add_history.go
+++ b/cmd/add_history.go
@@ -32,10 +32,24 @@ func NewAddHistoryCommand(conf config.Config) *cobra.Command {
 		},
 	}
 
+	command.PersistentFlags().BoolP("--skip-secrets", "s", false, `will skip secrets and sensitive informations`)
+
 	return command
 }
 
 func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) error {
+	if err := cmd.Flags().Parse(args); err != nil {
+		return err
+	}
+
+	flags := cmd.Flags()
+
+	//Get data from flags
+	shouldSkipSecrets, err := flags.GetBool("--skip-secrets")
+	if err != nil {
+		return fmt.Errorf("could not parse `--skip-secrets` flag: %s", err)
+	}
+
 	storeFile, storeData, storeBytes, err := loadStore(conf)
 	if err != nil {
 		return fmt.Errorf("failed to load the store: %s", err)
@@ -51,7 +65,29 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 		return fmt.Errorf("failed to get history records: %s", err)
 	}
 
-	addScriptsFromRecords(conf, records, storeData)
+	//Setup spinner
+	conf.Spin.Start()
+	defer conf.Spin.Stop()
+
+	dir, err := config.GetStoreDirPath(conf)
+	if err != nil {
+		return fmt.Errorf("failed get repository path: %s", err)
+	}
+
+	storeFilePath, err := config.GetStoreFilePath(conf)
+	if err != nil {
+		return fmt.Errorf("failed get store file path: %s", err)
+	}
+
+	conf.Spin.Message("pulling remote changes...")
+	err = pullRemoteChanges(conf, dir, storeFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to pull remote changes: %s", err)
+	}
+	conf.Spin.Message("remote changes pulled")
+
+	//Add history code records
+	addScriptsFromRecords(conf, records, storeData, shouldSkipSecrets)
 
 	//Save storeData in store
 	if err := saveStore(storeData, storeBytes, storeFile, tempFile); err != nil {
@@ -63,15 +99,28 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 		return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
 	}
 
-	fmt.Fprintln(conf.OutWriter, "Your history was successfully added!")
+	conf.Spin.Message("pushing local changes...")
+	err = pushLocalChanges(conf, dir, storeFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to push local changes: %s", err)
+	}
+	conf.Spin.Message("local changes pushed")
+
+	fmt.Fprintln(conf.OutWriter, "\nYour history was successfully added!")
 	return nil
 }
 
-func addScriptsFromRecords(conf config.Config, records []string, storeData *store.Store) *store.Store {
+func addScriptsFromRecords(conf config.Config, records []string, storeData *store.Store, shouldSkipSecrets bool) *store.Store {
 	size := len(records)
 	for i, record := range records {
+		conf.Spin.Message(fmt.Sprintf("%d/%d adding record...", i, size))
+
 		//Check if the code entry contains sensitive data
 		if ret, word := store.HasSensitiveData(record); ret {
+			if shouldSkipSecrets {
+				continue
+			}
+
 			fmt.Fprintf(conf.OutWriter, "Found the keyword `%s` in %s\n", word, record)
 			fmt.Fprintf(conf.OutWriter, "%d/%d records\n", i, size)
 			if !printers.Confirm("Add anyway ?") {
@@ -93,6 +142,8 @@ func addScriptsFromRecords(conf config.Config, records []string, storeData *stor
 
 		//Add new script entry in the `Store` struct
 		storeData.Scripts = append(storeData.Scripts, script)
+
+		conf.Spin.Message(fmt.Sprintf("%d/%d record successfully added!", i, size))
 	}
 
 	return storeData

--- a/cmd/add_history.go
+++ b/cmd/add_history.go
@@ -100,7 +100,7 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 	}
 
 	conf.Spin.Message("pushing local changes...")
-	err = pushLocalChanges(conf, dir, storeFilePath)
+	err = pushLocalChanges(conf, dir, storeFilePath, commitAddAction)
 	if err != nil {
 		return fmt.Errorf("failed to push local changes: %s", err)
 	}

--- a/cmd/add_solution.go
+++ b/cmd/add_solution.go
@@ -114,7 +114,7 @@ func addSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) e
 	spin.Suffix = " new entry successfully added"
 
 	spin.Suffix = " pushing local changes..."
-	err = pushLocalChanges(conf, dir, storeFilePath)
+	err = pushLocalChanges(conf, dir, storeFilePath, commitAddAction)
 	if err != nil {
 		return fmt.Errorf("failed to push local changes: %s", err)
 	}

--- a/cmd/add_solution_test.go
+++ b/cmd/add_solution_test.go
@@ -13,16 +13,6 @@ func TestAddSolutionCommand(t *testing.T) {
 	t.Run("make sure that is runs successfully", func(t *testing.T) {
 		conf, mockedExec := createConfig()
 
-		//Setup function calls mocks
-		mockedExec.On("DoGit", mock.Anything, "diff").Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "diff", mock.Anything).Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "stash").Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "stash", "apply").Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "pull", "--rebase", "origin", "master").Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "add", mock.Anything).Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "commit", "-m", mock.Anything).Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGitPush", mock.Anything, "origin", "master").Return(mock.Anything, nil).Once()
-
 		if err := setupFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)
 		}
@@ -49,7 +39,14 @@ func TestAddSolutionCommand(t *testing.T) {
 		got := writer.String()
 		exp := "\nYour solution was successfully added!\n"
 		assert.Equal(t, exp, got)
-		mockedExec.AssertExpectations(t)
+
+		//function call assert
+		mockedExec.AssertCalled(t, "DoGit", mock.Anything, "fetch", "origin", "master")
+		mockedExec.AssertCalled(t, "DoGit", mock.Anything, "diff", "origin/master", "--", mock.Anything)
+		mockedExec.AssertCalled(t, "DoGit", mock.Anything, "stash", "apply")
+		mockedExec.AssertCalled(t, "DoGit", mock.Anything, "add", mock.Anything)
+		mockedExec.AssertCalled(t, "DoGit", mock.Anything, "commit", "-m", "ckp: add entry")
+		mockedExec.AssertCalled(t, "DoGitPush", mock.Anything, "origin", "master")
 
 		if err := deleteFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/elhmn/ckp/internal/config"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -36,9 +34,8 @@ func NewInitCommand(conf config.Config) *cobra.Command {
 
 func initCommand(conf config.Config, remoteStorageFolder string) error {
 	//Setup spinner
-	spin := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-	spin.Start()
-	defer spin.Stop()
+	conf.Spin.Start()
+	defer conf.Spin.Stop()
 
 	home, err := homedir.Dir()
 	if err != nil {
@@ -55,10 +52,11 @@ func initCommand(conf config.Config, remoteStorageFolder string) error {
 
 	//clone remote storage folder
 	fmt.Fprintf(conf.OutWriter, "Initialising `%s` remote storage folder\n", remoteStorageFolder)
-	output, err := conf.Exec.DoGitClone(dir, remoteStorageFolder, conf.CKPStorageFolder)
+	out, err := conf.Exec.DoGitClone(dir, remoteStorageFolder, conf.CKPStorageFolder)
 	if err != nil {
-		return fmt.Errorf("failed to clone `%s`: %s\n%s", remoteStorageFolder, err, output)
+		return fmt.Errorf("failed to clone `%s`: %s\n%s", remoteStorageFolder, err, out)
 	}
+
 	fmt.Fprintf(conf.OutWriter, "`%s` remote storage folder, Initialised\n", remoteStorageFolder)
 
 	fmt.Fprintf(conf.OutWriter, "ckp successfully initialised\n")

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -71,10 +71,17 @@ func pushCommand(conf config.Config) error {
 
 func pullRemoteChanges(conf config.Config, dir, file string) error {
 	hasLocalChanges := false
-	out, err := conf.Exec.DoGit(dir, "diff")
+
+	out, err := conf.Exec.DoGit(dir, "fetch", "origin", "master")
+	if err != nil {
+		return fmt.Errorf("failed to fetch origin/master: %s: %s", err, out)
+	}
+
+	out, err = conf.Exec.DoGit(dir, "diff", "origin/master", "--", file)
 	if err != nil {
 		return fmt.Errorf("failed to check for local changes: %s: %s", err, out)
 	}
+
 	if out != "" {
 		hasLocalChanges = true
 	}
@@ -101,7 +108,12 @@ func pullRemoteChanges(conf config.Config, dir, file string) error {
 }
 
 func pushLocalChanges(conf config.Config, dir, file string) error {
-	out, err := conf.Exec.DoGit(dir, "diff", file)
+	out, err := conf.Exec.DoGit(dir, "fetch", "origin", "master")
+	if err != nil {
+		return fmt.Errorf("failed to fetch origin/master: %s: %s", err, out)
+	}
+
+	out, err = conf.Exec.DoGit(dir, "diff", "origin/master", "--", file)
 	if err != nil {
 		return fmt.Errorf("failed to check for local changes: %s: %s", err, out)
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -10,9 +10,10 @@ import (
 )
 
 const (
-	commitAddAction    = "add"
-	commitEditAction   = "edit"
-	commitRemoveAction = "rm"
+	commitAddAction     = "add"
+	commitEditAction    = "edit"
+	commitRemoveAction  = "rm"
+	commitDefaultAction = "push"
 )
 
 //NewPushCommand create new cobra command for the push command
@@ -59,7 +60,7 @@ func pushCommand(conf config.Config) error {
 	spin.Suffix = " remote changes pulled"
 
 	spin.Suffix = " pushing local changes..."
-	err = pushLocalChanges(conf, dir, storeFilePath)
+	err = pushLocalChanges(conf, dir, storeFilePath, commitDefaultAction)
 	if err != nil {
 		return fmt.Errorf("failed to push local changes: %s", err)
 	}
@@ -107,7 +108,7 @@ func pullRemoteChanges(conf config.Config, dir, file string) error {
 	return nil
 }
 
-func pushLocalChanges(conf config.Config, dir, file string) error {
+func pushLocalChanges(conf config.Config, dir, file string, action string) error {
 	out, err := conf.Exec.DoGit(dir, "fetch", "origin", "master")
 	if err != nil {
 		return fmt.Errorf("failed to fetch origin/master: %s: %s", err, out)
@@ -127,7 +128,7 @@ func pushLocalChanges(conf config.Config, dir, file string) error {
 		return fmt.Errorf("failed to add changes: %s: %s", err, out)
 	}
 
-	out, err = conf.Exec.DoGit(dir, "commit", "-m", getCommitMessage("push"))
+	out, err = conf.Exec.DoGit(dir, "commit", "-m", getCommitMessage(action))
 	if err != nil {
 		return fmt.Errorf("failed to commit changes: %s: %s", err, out)
 	}

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -15,15 +15,13 @@ import (
 func TestPushCommand(t *testing.T) {
 	getMockedExec := func() *mocks.IExec {
 		mockedExec := &mocks.IExec{}
-		mockedExec.On("DoGit", mock.Anything, "diff").Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "diff", mock.Anything).Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "stash").Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "stash", "apply").Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "pull", "--rebase", "origin", "master").Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "add", mock.Anything).Return(mock.Anything, nil).Once()
-		mockedExec.On("DoGit", mock.Anything, "commit", "-m", mock.Anything).Return(mock.Anything, nil).Once()
+		//Setup function calls mocks
+		mockedExec.On("DoGit", mock.Anything, mock.Anything).Return(mock.Anything, nil)
+		mockedExec.On("DoGit", mock.Anything, mock.Anything, mock.Anything).Return(mock.Anything, nil)
+		mockedExec.On("DoGit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mock.Anything, nil)
+		mockedExec.On("DoGit", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(mock.Anything, nil)
+		mockedExec.On("DoGitPush", mock.Anything, "origin", mock.Anything).Return(mock.Anything, nil)
 
-		mockedExec.On("DoGitPush", mock.Anything, "origin", "master").Return(mock.Anything, nil).Once()
 		return mockedExec
 	}
 
@@ -49,6 +47,11 @@ func TestPushCommand(t *testing.T) {
 			t.Errorf("expected failure with [%s], got [%s]", exp, got)
 		}
 
-		mockedExec.AssertExpectations(t)
+		mockedExec.AssertCalled(t, "DoGit", mock.Anything, "fetch", "origin", "master")
+		mockedExec.AssertCalled(t, "DoGit", mock.Anything, "diff", "origin/master", "--", mock.Anything)
+		mockedExec.AssertCalled(t, "DoGit", mock.Anything, "stash", "apply")
+		mockedExec.AssertCalled(t, "DoGit", mock.Anything, "add", mock.Anything)
+		mockedExec.AssertCalled(t, "DoGit", mock.Anything, "commit", "-m", "update: update store")
+		mockedExec.AssertCalled(t, "DoGitPush", mock.Anything, "origin", "master")
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,12 +6,15 @@ import (
 	"os"
 
 	"github.com/elhmn/ckp/internal/exec"
+	"github.com/elhmn/ckp/internal/printers"
 	"github.com/mitchellh/go-homedir"
 )
 
 const (
 	StoreFileName     = "repo/store.yaml"
 	StoreTempFileName = "repo/.temp_store.yaml"
+
+	MainBranch = "master"
 )
 
 //Config contains the entire cli dependencies
@@ -19,6 +22,16 @@ type Config struct {
 	Exec             exec.IExec
 	CKPDir           string
 	CKPStorageFolder string
+	Spin             printers.ISpinner
+
+	//MainBranch is a your remote repository main branch
+	MainBranch string
+
+	//WorkingBranch is `ckp` local working branch
+	//instead of using your main branch `ckp` uses a separate
+	//branch locally to facilite diff checks between your local
+	//and remote changes
+	WorkingBranch string
 
 	//io Writers useful for testing
 	OutWriter io.Writer
@@ -29,10 +42,13 @@ type Config struct {
 func NewDefaultConfig() Config {
 	return Config{
 		Exec:             exec.NewExec(),
+		Spin:             printers.NewSpinner(),
 		OutWriter:        os.Stdout,
 		ErrWriter:        os.Stderr,
 		CKPDir:           ".ckp",
 		CKPStorageFolder: "repo",
+		MainBranch:       MainBranch,
+		WorkingBranch:    "working-" + MainBranch,
 	}
 }
 

--- a/internal/printers/spinner.go
+++ b/internal/printers/spinner.go
@@ -1,0 +1,47 @@
+package printers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/briandowns/spinner"
+)
+
+//ISpinner defines a spinner interface
+type ISpinner interface {
+	Message(m string)
+	Clear()
+	Stop()
+	Start()
+}
+
+//Spinner is a spinner object
+type Spinner struct {
+	s *spinner.Spinner
+}
+
+//NewSpinner returns a new Spinner
+func NewSpinner() Spinner {
+	spin := Spinner{s: spinner.New(spinner.CharSets[11], 100*time.Millisecond)}
+	return spin
+}
+
+//Message will set the spinner suffix message
+func (s Spinner) Message(m string) {
+	s.s.Suffix = fmt.Sprintf(" %s", m)
+}
+
+//Clear will clear the spinner suffix
+func (s Spinner) Clear() {
+	s.s.Suffix = ""
+}
+
+//Stop stops the spinner
+func (s Spinner) Stop() {
+	s.s.Stop()
+}
+
+//Start starts the spinner
+func (s Spinner) Start() {
+	s.s.Start()
+}


### PR DESCRIPTION
#### This pull request will make sure that the local storage is being synchronised before and after the history is added

**Why ?**
As we did for the `ckp add code` and `ckp add solution` commands in #32 , we would like the `ckp add history` to synchronise
the storage before and after we have added the history

**How ?**
We initially pull changes from the remote storage repository, then we add history records as we did before this PR and finally we push this changes to the remote storage

**Steps to verify:**
1. Run `ckp add history --skip-scripts` command
2. Check whether or not your changes are in sync with the remote storage
