### PR TITLE
feat(reset): add reset command

### DIFF
--- a/cmd/add_code_test.go
+++ b/cmd/add_code_test.go
@@ -31,17 +31,26 @@ func createConfig() (config.Config, *mocks.IExec) {
 	return conf, mockedExec
 }
 
+func getTempStorageFolder(conf config.Config) (string, error) {
+	home, err := homedir.Dir()
+	if err != nil {
+		return "", fmt.Errorf("failed to read home directory: %s", err)
+	}
+
+	return fmt.Sprintf("%s/%s/%s", home, conf.CKPDir, conf.CKPStorageFolder), nil
+}
+
 func setupFolder(conf config.Config) error {
 	if err := deleteFolder(conf); err != nil {
 		return fmt.Errorf("Error: failed to delete folder: %s", err)
 	}
 
-	home, err := homedir.Dir()
+	folder, err := getTempStorageFolder(conf)
 	if err != nil {
-		return fmt.Errorf("failed to read home directory: %s", err)
+		return fmt.Errorf("failed to get temporary storage folder: %s", err)
 	}
 
-	if err = os.MkdirAll(fmt.Sprintf("%s/%s/%s", home, conf.CKPDir, conf.CKPStorageFolder), 0777); err != nil {
+	if err = os.MkdirAll(folder, 0777); err != nil {
 		return err
 	}
 
@@ -58,7 +67,7 @@ func deleteFolder(conf config.Config) error {
 }
 
 func TestAddCodeCommand(t *testing.T) {
-	t.Run("make sure that is runs successfully", func(t *testing.T) {
+	t.Run("make sure that it runs successfully", func(t *testing.T) {
 		conf, mockedExec := createConfig()
 
 		if err := setupFolder(conf); err != nil {

--- a/cmd/ckp.go
+++ b/cmd/ckp.go
@@ -14,6 +14,7 @@ func NewCKPCommand(config config.Config) *cobra.Command {
 	}
 
 	ckpCommand.AddCommand(NewInitCommand(config))
+	ckpCommand.AddCommand(NewResetCommand(config))
 	ckpCommand.AddCommand(NewAddCommand(config))
 	ckpCommand.AddCommand(NewListCommand(config))
 	ckpCommand.AddCommand(NewFindCommand(config))

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/elhmn/ckp/internal/config"
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+)
+
+//NewResetCommand create new cobra command for the reset command
+func NewResetCommand(conf config.Config) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "reset",
+		Short: "reset removes the current remote storage repository",
+		Long: `reset removes the current remote storage repository
+
+		example: ckp reset
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := resetCommand(conf); err != nil {
+				fmt.Fprintf(conf.OutWriter, "Error: %s\n", err)
+				return
+			}
+		},
+	}
+
+	return command
+}
+
+func resetCommand(conf config.Config) error {
+	//Setup spinner
+	conf.Spin.Start()
+	defer conf.Spin.Stop()
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return fmt.Errorf("failed to read home directory: %s", err)
+	}
+
+	//Delete the temporary file
+	dir := fmt.Sprintf("%s/%s/%s", home, conf.CKPDir, conf.CKPStorageFolder)
+	if err := os.RemoveAll(dir); err != nil {
+		return fmt.Errorf("failed to remote storage %s: %s", dir, err)
+	}
+
+	fmt.Fprintf(conf.OutWriter, "ckp was successfully reset\n")
+	return nil
+}

--- a/cmd/reset_test.go
+++ b/cmd/reset_test.go
@@ -1,0 +1,56 @@
+package cmd_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/elhmn/ckp/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResetommand(t *testing.T) {
+	t.Run("make sure that it runs successfully", func(t *testing.T) {
+		conf, _ := createConfig()
+
+		if err := setupFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		commandName := "reset"
+		command := cmd.NewResetCommand(conf)
+
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		//Set args
+		command.SetArgs([]string{commandName})
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		//Get remote storage folder
+		folder, err := getTempStorageFolder(conf)
+		if err != nil {
+			t.Errorf("failed to get temporary storage folder: %s: %s", folder, err)
+		}
+
+		//Assert that the command deleted the remote storage folder
+		if _, err := os.Stat(folder); !os.IsNotExist(err) {
+			t.Errorf("Failed to remove %s folder : %s", folder, err)
+		}
+
+		got := writer.String()
+		exp := "ckp was successfully reset\n"
+		assert.Equal(t, exp, got)
+
+		if err := deleteFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+	})
+}

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -1,0 +1,40 @@
+package files
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/mitchellh/go-homedir"
+)
+
+//CopyFileToHomeDirectory copy the file at `filepath` to the home directory
+func CopyFileToHomeDirectory(filepath, contentPath string) error {
+	content, err := ioutil.ReadFile(contentPath)
+	if err != nil {
+		return fmt.Errorf("failed to read file %s data: %s", contentPath, err)
+	}
+
+	home, err := homedir.Dir()
+	if err != nil {
+		return fmt.Errorf("failed to read home directory: %s", err)
+	}
+	destination := fmt.Sprintf("%s/%s", home, filepath)
+
+	//Copy the store file to a temporary destination
+	if err := ioutil.WriteFile(destination, content, 0666); err != nil {
+		return fmt.Errorf("failed to write to file %s: %s", filepath, err)
+	}
+
+	return nil
+}
+
+//DeleteFileFromHomeDirectory delete the file at `filepath` from the home directory
+func DeleteFileFromHomeDirectory(filepath string) error {
+	home, err := homedir.Dir()
+	if err != nil {
+		return fmt.Errorf("failed to read home directory: %s", err)
+	}
+
+	return os.Remove(fmt.Sprintf("%s/%s", home, filepath))
+}


### PR DESCRIPTION
#### This pull request implements the `ckp reset command`

**Why ?**
We would like to remove the current remote storage repository so that we can initialise a new one using `ckp init <remote_storage_repository>`

**How ?**
It removes the `~/.ckp/repo` folder

**Steps to verify:**
Run `ckp reset` then move to `~/.ckp` and `ls` to check if the folder exists