### PR TITLE
feat: improve fuzzy search

### DIFF
--- a/cmd/find_internal_test.go
+++ b/cmd/find_internal_test.go
@@ -38,7 +38,7 @@ func TestDoesScriptContain(t *testing.T) {
 			Solution: store.Solution{Content: "ma solution"},
 		},
 		},
-		{Input: "comment alias", Exp: false, S: store.Script{
+		{Input: "comment alias", Exp: true, S: store.Script{
 			Comment:  "my comment",
 			Code:     store.Code{Content: "je suis con", Alias: "mon alias"},
 			Solution: store.Solution{Content: "ma solution"},
@@ -48,7 +48,7 @@ func TestDoesScriptContain(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("%d - test for \"%s\" equal %v", i, test.Input, test.Exp), func(t *testing.T) {
-			assert.Equal(t, doesScriptContain(test.S, test.Input), test.Exp)
+			assert.Equal(t, test.Exp, doesScriptContain(test.S, test.Input))
 		})
 	}
 }


### PR DESCRIPTION
#### This pull request improves the search algorithm used for the `find` and `rm` command

**Why ?**
Searching commands is a very important feature, but the previous search algorithm was very basic.

**How ?**
The new search algorithm splits the input string into a slice of words. These words were present in the input string and separated by spaces. 

**Steps to verify:**
1. Add a new entry in your history, running `ckp add code "echo salut boris comment vas tu"`
2. Run `ckp find`
3. In the search input, write `salut com`
4. you should see the `echo salut boris comment vas tu` entry appear in the list