### PR TITLE
Add ckp run command

### DIFF
--- a/cmd/ckp.go
+++ b/cmd/ckp.go
@@ -21,5 +21,6 @@ func NewCKPCommand(config config.Config) *cobra.Command {
 	ckpCommand.AddCommand(NewPushCommand(config))
 	ckpCommand.AddCommand(NewPullCommand(config))
 	ckpCommand.AddCommand(NewRmCommand(config))
+	ckpCommand.AddCommand(NewRunCommand(config))
 	return ckpCommand
 }

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const selectItemsSize = 10
+
 //NewFindCommand display a prompt for you to enter the code or solution you are looking for
 func NewFindCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
@@ -102,7 +104,7 @@ func findCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 	prompt := promptui.Select{
 		Label:             "Enter your search text",
 		Items:             scripts,
-		Size:              10,
+		Size:              selectItemsSize,
 		StartInSearchMode: true,
 		Searcher:          searchScript,
 		Templates:         getTemplates(),

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -117,7 +117,7 @@ func selectScriptEntry(scripts []store.Script) (int, error) {
 	prompt := promptui.Select{
 		Label:             "Enter your search text",
 		Items:             scripts,
-		Size:              5,
+		Size:              selectItemsSize,
 		StartInSearchMode: true,
 		Searcher:          searchScript,
 		Templates:         getTemplates(),

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/elhmn/ckp/internal/config"
+	"github.com/elhmn/ckp/internal/store"
+	"github.com/spf13/cobra"
+)
+
+//NewRunCommand create new cobra command for the run command
+func NewRunCommand(conf config.Config) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "run [code_id]",
+		Short: "run run your code entries from the store",
+		Long: `run run your code entries from the store
+
+		example: ckp run
+		Will prompt an interactive UI that will allow you to search and run
+		a code entry
+
+		example: ckp run <entry_id>
+		Will run the entry corresponding the entry_id
+`,
+		Run: func(cmd *cobra.Command, args []string) {
+			var entryID string
+			if len(args) >= 1 {
+				entryID = args[0]
+			}
+
+			if err := runCommand(conf, entryID); err != nil {
+				fmt.Fprintf(conf.OutWriter, "Error: %s\n", err)
+				return
+			}
+		},
+	}
+
+	return command
+}
+
+func runCommand(conf config.Config, entryID string) error {
+	_, storeData, _, err := loadStore(conf)
+	if err != nil {
+		return fmt.Errorf("failed to load the store: %s", err)
+	}
+
+	index, err := getScriptEntryIndex(conf, storeData.Scripts, entryID)
+	if err != nil {
+		return fmt.Errorf("failed to get script `%s` entry index: %s", entryID, err)
+	}
+
+	if err := runCodeEntry(conf, storeData.Scripts, index); err != nil {
+		return fmt.Errorf("failed to run code entry: %s", err)
+	}
+	return nil
+}
+
+func runCodeEntry(conf config.Config, scripts []store.Script, index int) error {
+	script := scripts[index]
+	if script.Code.Content == "" {
+		return fmt.Errorf("might not be a code entry, nothing to run")
+	}
+
+	return conf.Exec.RunInteractive("bash", "-c", script.Code.Content)
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,80 @@
+package cmd_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/elhmn/ckp/cmd"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRunCommand(t *testing.T) {
+	t.Run("make sure that it runs successfully", func(t *testing.T) {
+		conf, mockedExec := createConfig(t)
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		if err := setupFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		//Specify expectations
+		gomock.InOrder(
+			mockedExec.EXPECT().RunInteractive("bash", "-c", "echo \"mon code\"\n"),
+		)
+
+		command := cmd.NewRunCommand(conf)
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		//Set args
+		command.SetArgs([]string{"hash-of-file-content"})
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		//function call assert
+		if err := deleteFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+	})
+
+	t.Run("fail with solution id", func(t *testing.T) {
+		conf, mockedExec := createConfig(t)
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		if err := setupFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		//Specify expectations
+		gomock.InOrder(
+			mockedExec.EXPECT().RunInteractive("bash", "-c", "echo \"mon code\"\n").Times(0),
+		)
+
+		command := cmd.NewRunCommand(conf)
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		//Set args
+		command.SetArgs([]string{"hash-of-file-content-2"})
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		got := writer.String()
+		exp := "might not be a code entry, nothing to run"
+		assert.Contains(t, got, exp)
+
+		//function call assert
+		if err := deleteFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+	})
+}

--- a/fixtures/store.yaml
+++ b/fixtures/store.yaml
@@ -3,8 +3,6 @@ scripts:
     creationtime: 2021-05-08T13:08:34.323371+02:00
     updatetime: 2021-05-08T13:08:34.323371+02:00
     comment: "a basic comment"
-    solution:
-      content: link to your hashnode or medium article
     code:
       alias: "an alias"
       content: |

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -2,12 +2,13 @@ package exec
 
 import (
 	"os"
-	"os/exec"
+	exe "os/exec"
 )
 
 //IExec defines exec global interface, useful for testing
 type IExec interface {
 	Run(dir string, command string, args ...string) ([]byte, error)
+	RunInteractive(command string, args ...string) error
 	DoGitClone(dir string, args ...string) (string, error)
 	DoGitPush(dir string, args ...string) (string, error)
 	DoGit(dir string, args ...string) (string, error)
@@ -35,7 +36,16 @@ func (ex Exec) CreateFolderIfDoesNotExist(dir string) error {
 
 //Run run command and return output
 func (ex Exec) Run(dir string, command string, args ...string) ([]byte, error) {
-	cmd := exec.Command(command, args...)
+	cmd := exe.Command(command, args...)
 	cmd.Dir = dir
 	return cmd.CombinedOutput()
+}
+
+//RunInteractive run the command in interactive mode
+func (ex Exec) RunInteractive(command string, args ...string) error {
+	cmd := exe.Command(command, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
 }

--- a/mocks/IExec.go
+++ b/mocks/IExec.go
@@ -126,3 +126,22 @@ func (mr *MockIExecMockRecorder) Run(dir, command interface{}, args ...interface
 	varargs := append([]interface{}{dir, command}, args...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Run", reflect.TypeOf((*MockIExec)(nil).Run), varargs...)
 }
+
+// RunInteractive mocks base method.
+func (m *MockIExec) RunInteractive(command string, args ...string) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{command}
+	for _, a := range args {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RunInteractive", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunInteractive indicates an expected call of RunInteractive.
+func (mr *MockIExecMockRecorder) RunInteractive(command interface{}, args ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{command}, args...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInteractive", reflect.TypeOf((*MockIExec)(nil).RunInteractive), varargs...)
+}


### PR DESCRIPTION
#### This pull request implements the `ckp run` command

**Why ?**
We wanted to be able to run code entry directly using `ckp`

**How ?**
The `run` command gets a `<entry_id>` parameter and run the code stored in this entry object,
the command can also be ran without arguments and it will prompt a selection UI you can use
to search a command and run it with ckp.

**Steps to verify:**
1. Run `ckp run` without entry
2. Select a command and press enter