### PR TITLE
Add history to separate history file

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -9,8 +9,8 @@ import (
 func NewAddCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "add",
-		Short: "add will store your code snippets or solutions",
-		Long: `add will store your code snippets or solutions
+		Short: "will store your code snippets or solutions",
+		Long: `will store your code snippets or solutions
 
 	example: ckp add code 'echo je suis con'
 	Will store 'echo je suis con' as a code asset in your solution repository

--- a/cmd/add_code.go
+++ b/cmd/add_code.go
@@ -20,8 +20,8 @@ func NewAddCodeCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:     "code <your_code>",
 		Aliases: []string{"c"},
-		Short:   "add code will store your code",
-		Long: `add code will store your code in your solution repository
+		Short:   "will store your code",
+		Long: `will store your code in your solution repository
 
 	example: ckp add code 'echo this is my command'
 	Will store 'echo this is my command' as a code asset in your solution repository

--- a/cmd/add_code.go
+++ b/cmd/add_code.go
@@ -81,7 +81,7 @@ func addCodeCommand(cmd *cobra.Command, args []string, conf config.Config) error
 	spin.Suffix = " remote changes pulled"
 
 	spin.Suffix = " adding new code entry..."
-	storeFile, storeData, storeBytes, err := loadStore(conf)
+	storeFile, storeData, storeBytes, err := loadStore(storeFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to load the store: %s", err)
 	}
@@ -158,30 +158,12 @@ func createHistoryTempFile(conf config.Config, storeBytes []byte) (string, error
 	return tempFile, nil
 }
 
-func loadStore(conf config.Config) (string, *store.Store, []byte, error) {
-	storeFile, err := config.GetStoreFilePath(conf)
-	if err != nil {
-		return storeFile, nil, nil, fmt.Errorf("failed to get the store file path: %s", err)
-	}
-
+func loadStore(storeFile string) (string, *store.Store, []byte, error) {
 	storeData, storeBytes, err := store.LoadStore(storeFile)
 	if err != nil {
 		return storeFile, storeData, storeBytes, fmt.Errorf("failed to load store: %s", err)
 	}
 	return storeFile, storeData, storeBytes, nil
-}
-
-func loadHistoryStore(conf config.Config) (string, *store.Store, []byte, error) {
-	historyFile, err := config.GetHistoryFilePath(conf)
-	if err != nil {
-		return historyFile, nil, nil, fmt.Errorf("failed to get the history store file path: %s", err)
-	}
-
-	storeData, storeBytes, err := store.LoadStore(historyFile)
-	if err != nil {
-		return historyFile, storeData, storeBytes, fmt.Errorf("failed to load history store: %s", err)
-	}
-	return historyFile, storeData, storeBytes, nil
 }
 
 func saveStore(storeData *store.Store, storeBytes []byte, storeFile, tempFile string) error {

--- a/cmd/add_history.go
+++ b/cmd/add_history.go
@@ -50,12 +50,12 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 		return fmt.Errorf("could not parse `--skip-secrets` flag: %s", err)
 	}
 
-	storeFile, storeData, storeBytes, err := loadStore(conf)
+	storeFile, storeData, storeBytes, err := loadHistoryStore(conf)
 	if err != nil {
 		return fmt.Errorf("failed to load the store: %s", err)
 	}
 
-	tempFile, err := createTempFile(conf, storeBytes)
+	tempFile, err := createHistoryTempFile(conf, storeBytes)
 	if err != nil {
 		return fmt.Errorf("failed to create tempFile: %s", err)
 	}
@@ -74,13 +74,13 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 		return fmt.Errorf("failed get repository path: %s", err)
 	}
 
-	storeFilePath, err := config.GetStoreFilePath(conf)
+	historyStoreFilePath, err := config.GetHistoryFilePath(conf)
 	if err != nil {
 		return fmt.Errorf("failed get store file path: %s", err)
 	}
 
 	conf.Spin.Message("pulling remote changes...")
-	err = pullRemoteChanges(conf, dir, storeFilePath)
+	err = pullRemoteChanges(conf, dir, historyStoreFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to pull remote changes: %s", err)
 	}
@@ -100,7 +100,7 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 	}
 
 	conf.Spin.Message("pushing local changes...")
-	err = pushLocalChanges(conf, dir, storeFilePath, commitAddAction)
+	err = pushLocalChanges(conf, dir, commitAddAction, historyStoreFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to push local changes: %s", err)
 	}

--- a/cmd/add_history.go
+++ b/cmd/add_history.go
@@ -17,8 +17,8 @@ func NewAddHistoryCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:     "history",
 		Aliases: []string{"h"},
-		Short:   "add history will store code from your shell history",
-		Long: `add history will store code from your shell history
+		Short:   "will store code from your shell history",
+		Long: `will store code from your shell history
 	it will read your .bash_history and zsh_history files and store
 	every script oneliner as a code entry in your store.yaml file
 

--- a/cmd/add_history.go
+++ b/cmd/add_history.go
@@ -50,7 +50,12 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 		return fmt.Errorf("could not parse `--skip-secrets` flag: %s", err)
 	}
 
-	storeFile, storeData, storeBytes, err := loadHistoryStore(conf)
+	historyStoreFilePath, err := config.GetHistoryFilePath(conf)
+	if err != nil {
+		return fmt.Errorf("failed get store file path: %s", err)
+	}
+
+	_, storeData, storeBytes, err := loadStore(historyStoreFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to load the store: %s", err)
 	}
@@ -74,11 +79,6 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 		return fmt.Errorf("failed get repository path: %s", err)
 	}
 
-	historyStoreFilePath, err := config.GetHistoryFilePath(conf)
-	if err != nil {
-		return fmt.Errorf("failed get store file path: %s", err)
-	}
-
 	conf.Spin.Message("pulling remote changes...")
 	err = pullRemoteChanges(conf, dir, historyStoreFilePath)
 	if err != nil {
@@ -90,8 +90,8 @@ func addHistoryCommand(cmd *cobra.Command, args []string, conf config.Config) er
 	addScriptsFromRecords(conf, records, storeData, shouldSkipSecrets)
 
 	//Save storeData in store
-	if err := saveStore(storeData, storeBytes, storeFile, tempFile); err != nil {
-		return fmt.Errorf("failed to save store in %s:  %s", storeFile, err)
+	if err := saveStore(storeData, storeBytes, historyStoreFilePath, tempFile); err != nil {
+		return fmt.Errorf("failed to save store in %s:  %s", historyStoreFilePath, err)
 	}
 
 	//Delete the temporary file

--- a/cmd/add_solution.go
+++ b/cmd/add_solution.go
@@ -114,7 +114,7 @@ func addSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) e
 	spin.Suffix = " new entry successfully added"
 
 	spin.Suffix = " pushing local changes..."
-	err = pushLocalChanges(conf, dir, storeFilePath, commitAddAction)
+	err = pushLocalChanges(conf, dir, commitAddAction, storeFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to push local changes: %s", err)
 	}

--- a/cmd/add_solution.go
+++ b/cmd/add_solution.go
@@ -75,7 +75,7 @@ func addSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) e
 	spin.Suffix = " remote changes pulled"
 
 	spin.Suffix = " adding new solution entry..."
-	storeFile, storeData, storeBytes, err := loadStore(conf)
+	_, storeData, storeBytes, err := loadStore(storeFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to load the store: %s", err)
 	}
@@ -103,8 +103,8 @@ func addSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) e
 	storeData.Scripts = append(storeData.Scripts, script)
 
 	//Save storeData in store
-	if err := saveStore(storeData, storeBytes, storeFile, tempFile); err != nil {
-		return fmt.Errorf("failed to save store in %s:  %s", storeFile, err)
+	if err := saveStore(storeData, storeBytes, storeFilePath, tempFile); err != nil {
+		return fmt.Errorf("failed to save store in %s:  %s", storeFilePath, err)
 	}
 
 	//Delete the temporary file

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -76,8 +76,18 @@ func initCommand(conf config.Config, remoteStorageFolder string) error {
 				return fmt.Errorf("failed to write to file %s: %s", storeFilePath, err)
 			}
 
+			historyStoreFilePath, err := config.GetHistoryFilePath(conf)
+			if err != nil {
+				return fmt.Errorf("failed get history store file path: %s", err)
+			}
+
+			//Create the history storage file
+			if err = ioutil.WriteFile(historyStoreFilePath, []byte{}, 0666); err != nil {
+				return fmt.Errorf("failed to write to file %s: %s", historyStoreFilePath, err)
+			}
+
 			//Add storage file
-			out, err = conf.Exec.DoGit(localStorageFolder, "add", storeFilePath)
+			out, err = conf.Exec.DoGit(localStorageFolder, "add", storeFilePath, historyStoreFilePath)
 			if err != nil {
 				return fmt.Errorf("failed to add changes: %s: %s", err, out)
 			}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -14,8 +14,8 @@ import (
 func NewInitCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "init <storage_repository>",
-		Short: "init initialise ckp storage repository",
-		Long: `init will initialise a storage repository
+		Short: "initialise ckp storage repository",
+		Long: `will initialise a storage repository
 
 		example: ckp init <https://github.com/elhmn/solutions>
 		This git repository will be used as your storage

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -23,6 +23,9 @@ func NewListCommand(conf config.Config) *cobra.Command {
 	example: ckp list --limit 20
 	Will list your first 20 code snippets and solutions
 
+	example: ckp list --from-history
+	Will list your first 20 code snippets and solutions
+
 	example: ckp list --all
 	Will list all your code snippets and solutions
 
@@ -44,6 +47,7 @@ func NewListCommand(conf config.Config) *cobra.Command {
 	command.PersistentFlags().BoolP("code", "c", false, `list your code records only`)
 	command.PersistentFlags().BoolP("solution", "s", false, `list your solutions only`)
 	command.PersistentFlags().BoolP("all", "a", false, `list all your code and solutions`)
+	command.PersistentFlags().Bool("from-history", false, `list code and solution records from history`)
 
 	return command
 }
@@ -72,11 +76,23 @@ func listCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 	if err != nil {
 		return fmt.Errorf("could not parse `all` flag: %s", err)
 	}
+	fromHistory, err := flags.GetBool("from-history")
+	if err != nil {
+		return fmt.Errorf("could not parse `fromHistory` flag: %s", err)
+	}
 
 	//get store data
-	storeFile, err := config.GetStoreFilePath(conf)
-	if err != nil {
-		return fmt.Errorf("failed to get the store file path: %s", err)
+	var storeFile string
+	if !fromHistory {
+		storeFile, err = config.GetStoreFilePath(conf)
+		if err != nil {
+			return fmt.Errorf("failed to get the store file path: %s", err)
+		}
+	} else {
+		storeFile, err = config.GetHistoryFilePath(conf)
+		if err != nil {
+			return fmt.Errorf("failed to get the history store file path: %s", err)
+		}
 	}
 
 	storeData, _, err := store.LoadStore(storeFile)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -14,8 +14,8 @@ func NewListCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:     "list",
 		Aliases: []string{"l"},
-		Short:   "list will display your code snippets and solutions",
-		Long: `list will display the code snippets and solutions you have stored
+		Short:   "will display your code snippets and solutions",
+		Long: `will display the code snippets and solutions you have stored
 
 	example: ckp list
 	Will list your first 10 code snippets and solutions

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -45,8 +45,13 @@ func pullCommand(conf config.Config) error {
 		return fmt.Errorf("failed get store file path: %s", err)
 	}
 
+	historyStoreFilePath, err := config.GetHistoryFilePath(conf)
+	if err != nil {
+		return fmt.Errorf("failed get history store file path: %s", err)
+	}
+
 	spin.Suffix = " pulling remote changes..."
-	err = pullRemoteChanges(conf, dir, storeFilePath)
+	err = pullRemoteChanges(conf, dir, storeFilePath, historyStoreFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to pull remote changes: %s", err)
 	}

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -13,8 +13,8 @@ import (
 func NewPullCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "pull",
-		Short: "pull changes from remote storage repository",
-		Long: `pull changes from remote storage repository
+		Short: "pulls changes from remote storage repository",
+		Long: `pulls changes from remote storage repository
 
 		example: ckp pull
 `,

--- a/cmd/pull_test.go
+++ b/cmd/pull_test.go
@@ -19,7 +19,7 @@ func TestPullCommand(t *testing.T) {
 		//Specify expectations
 		gomock.InOrder(
 			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
-			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any(), gomock.Any()),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "pull", "--rebase", "origin", "main"),
 		)
 

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -21,8 +21,8 @@ const (
 func NewPushCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "push",
-		Short: "push your changes to your remote repository",
-		Long: `push your changed to your remote repository
+		Short: "pushes your changes to your remote repository",
+		Long: `pushes your changed to your remote repository
 
 		example: ckp push
 `,

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -19,11 +19,11 @@ func TestPushCommand(t *testing.T) {
 		//Specify expectations
 		gomock.InOrder(
 			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
-			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any(), gomock.Any()),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "pull", "--rebase", "origin", "main"),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
-			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
-			mockedExec.EXPECT().DoGit(gomock.Any(), "add", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any(), gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "add", gomock.Any(), gomock.Any()),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "commit", "-m", "ckp: add store"),
 		)
 

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -13,8 +13,8 @@ import (
 func NewResetCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "reset",
-		Short: "reset removes the current remote storage repository",
-		Long: `reset removes the current remote storage repository
+		Short: "removes the current remote storage repository",
+		Long: `removes the current remote storage repository
 
 		example: ckp reset
 `,

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -14,8 +14,8 @@ import (
 func NewRmCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "rm [code_id | solution_id]",
-		Short: "rm removes code or solution entries from the store",
-		Long: `rm removes code or solution entries from the store
+		Short: "removes code or solution entries from the store",
+		Long: `removes code or solution entries from the store
 
 		example: ckp rm
 		Will prompt an interactive UI that will allow you to search and delete

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -92,7 +92,7 @@ func rmCommand(conf config.Config, entryID string) error {
 	}
 
 	conf.Spin.Message(" pushing local changes...")
-	err = pushLocalChanges(conf, dir, storeFilePath, commitRemoveAction)
+	err = pushLocalChanges(conf, dir, commitRemoveAction, storeFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to push local changes: %s", err)
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -12,8 +12,8 @@ import (
 func NewRunCommand(conf config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "run [code_id]",
-		Short: "run run your code entries from the store",
-		Long: `run run your code entries from the store
+		Short: "runs your code entries from the store",
+		Long: `runs your code entries from the store
 
 		example: ckp run
 		Will prompt an interactive UI that will allow you to search and run

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,25 +23,45 @@ func NewRunCommand(conf config.Config) *cobra.Command {
 		Will run the entry corresponding the entry_id
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			var entryID string
-			if len(args) >= 1 {
-				entryID = args[0]
-			}
-
-			if err := runCommand(conf, entryID); err != nil {
+			if err := runCommand(cmd, args, conf); err != nil {
 				fmt.Fprintf(conf.OutWriter, "Error: %s\n", err)
 				return
 			}
 		},
 	}
 
+	command.PersistentFlags().Bool("from-history", false, `list code and solution records from history`)
+
 	return command
 }
 
-func runCommand(conf config.Config, entryID string) error {
-	storeFilePath, err := config.GetStoreFilePath(conf)
+func runCommand(cmd *cobra.Command, args []string, conf config.Config) error {
+	var entryID string
+	if len(args) >= 1 {
+		entryID = args[0]
+	}
+
+	if err := cmd.Flags().Parse(args); err != nil {
+		return err
+	}
+	flags := cmd.Flags()
+	fromHistory, err := flags.GetBool("from-history")
 	if err != nil {
-		return fmt.Errorf("failed to get the store file path: %s", err)
+		return fmt.Errorf("could not parse `fromHistory` flag: %s", err)
+	}
+
+	//Get the store file path
+	var storeFilePath string
+	if !fromHistory {
+		storeFilePath, err = config.GetStoreFilePath(conf)
+		if err != nil {
+			return fmt.Errorf("failed to get the store file path: %s", err)
+		}
+	} else {
+		storeFilePath, err = config.GetHistoryFilePath(conf)
+		if err != nil {
+			return fmt.Errorf("failed to get the history store file path: %s", err)
+		}
 	}
 
 	_, storeData, _, err := loadStore(storeFilePath)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -39,7 +39,12 @@ func NewRunCommand(conf config.Config) *cobra.Command {
 }
 
 func runCommand(conf config.Config, entryID string) error {
-	_, storeData, _, err := loadStore(conf)
+	storeFilePath, err := config.GetStoreFilePath(conf)
+	if err != nil {
+		return fmt.Errorf("failed to get the store file path: %s", err)
+	}
+
+	_, storeData, _, err := loadStore(storeFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to load the store: %s", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	StoreFileName     = "repo/store.yaml"
-	StoreTempFileName = "repo/.temp_store.yaml"
+	StoreFileName            = "repo/store.yaml"
+	HistoryFileName          = "repo/history_store.yaml"
+	StoreTempFileName        = "repo/.temp_store.yaml"
+	StoreHistoryTempFileName = "repo/.temp_history_store.yaml"
 
 	MainBranch = "main"
 )
@@ -63,6 +65,17 @@ func GetStoreFilePath(conf Config) (string, error) {
 	return storepath, nil
 }
 
+//GetHistoryFilePath get the store file path from config
+func GetHistoryFilePath(conf Config) (string, error) {
+	home, err := homedir.Dir()
+	if err != nil {
+		return "", fmt.Errorf("failed to read home directory: %s", err)
+	}
+
+	storepath := fmt.Sprintf("%s/%s/%s", home, conf.CKPDir, HistoryFileName)
+	return storepath, nil
+}
+
 //GetTempStoreFilePath get the temporary store file path from config
 func GetTempStoreFilePath(conf Config) (string, error) {
 	home, err := homedir.Dir()
@@ -71,6 +84,17 @@ func GetTempStoreFilePath(conf Config) (string, error) {
 	}
 
 	storepath := fmt.Sprintf("%s/%s/%s", home, conf.CKPDir, StoreTempFileName)
+	return storepath, nil
+}
+
+//GetTempHistoryStoreFilePath get the temporary store file path from config
+func GetTempHistoryStoreFilePath(conf Config) (string, error) {
+	home, err := homedir.Dir()
+	if err != nil {
+		return "", fmt.Errorf("failed to read home directory: %s", err)
+	}
+
+	storepath := fmt.Sprintf("%s/%s/%s", home, conf.CKPDir, StoreHistoryTempFileName)
 	return storepath, nil
 }
 


### PR DESCRIPTION
#### write history to a `history_store.yaml` file

**Why ?**
History can become quite heavy in size and contain a lot of noise, so we would like to keep our manually added scritps
from the main `store.yaml` file

**How ?**
we save it in a separate file

**Steps to verify:**
Run `ckp add history --skip-secrets` this will create a file at `~/.ckp/repo/history_store.yaml`, open this file and check if anything was added at all
