### PR TITLE
feat: add command from path

### DIFF
--- a/cmd/add_code.go
+++ b/cmd/add_code.go
@@ -38,6 +38,7 @@ func NewAddCodeCommand(conf config.Config) *cobra.Command {
 	}
 
 	command.PersistentFlags().StringP("alias", "a", "", `ckp add -a <alias>`)
+	command.PersistentFlags().StringP("path", "p", "", `ckp add -p <script_path>`)
 
 	return command
 }
@@ -196,6 +197,18 @@ func createNewCodeScriptEntry(code string, flags *flag.FlagSet) (store.Script, e
 	comment, err := flags.GetString("comment")
 	if err != nil {
 		return store.Script{}, fmt.Errorf("could not parse `comment` flag: %s", err)
+	}
+	path, err := flags.GetString("path")
+	if err != nil {
+		return store.Script{}, fmt.Errorf("could not parse `path` flag: %s", err)
+	}
+
+	if path != "" {
+		bytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			return store.Script{}, fmt.Errorf("failed to read %s: %s", path, err)
+		}
+		code = string(bytes)
 	}
 
 	//Generate script entry unique id

--- a/cmd/add_solution.go
+++ b/cmd/add_solution.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -32,6 +33,8 @@ func NewAddSolutionCommand(conf config.Config) *cobra.Command {
 			}
 		},
 	}
+
+	command.PersistentFlags().StringP("path", "p", "", `add code from path`)
 
 	return command
 }
@@ -131,6 +134,18 @@ func createNewSolutionScriptEntry(solution string, flags *flag.FlagSet) (store.S
 	comment, err := flags.GetString("comment")
 	if err != nil {
 		return store.Script{}, fmt.Errorf("could not parse `comment` flag: %s", err)
+	}
+	path, err := flags.GetString("path")
+	if err != nil {
+		return store.Script{}, fmt.Errorf("could not parse `path` flag: %s", err)
+	}
+
+	if path != "" {
+		bytes, err := ioutil.ReadFile(path)
+		if err != nil {
+			return store.Script{}, fmt.Errorf("failed to read %s: %s", path, err)
+		}
+		solution = string(bytes)
 	}
 
 	//Generate script entry unique id

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -37,27 +37,32 @@ func NewFindCommand(conf config.Config) *cobra.Command {
 	return command
 }
 
+func trimText(s string) string {
+	if len(s) > 50 {
+		return s[:50] + "..."
+	}
+	return s
+}
+
 func getTemplates() *promptui.SelectTemplates {
 	funcMap := promptui.FuncMap
-	funcMap["trimText"] = func(s string) string {
-		if len(s) > 50 {
-			return s[:50] + "..."
-		}
-		return s
+	funcMap["inline"] = func(s string) string {
+		return strings.ReplaceAll(trimText(s), "\n", " ")
 	}
+
 	//if you find a hard time understand it check out golang templating format documentation
 	//here https://golang.org/pkg/text/template
 	return &promptui.SelectTemplates{
 		Label: "{{ if .Code.Content -}} {{`code:` | bold | green}} " +
-			"{{ trimText .Code.Content}} {{- else -}} {{ trimText .Solution.Content }} {{ end }}",
-		Active: "* {{ if .Code.Content -}} {{`code:` | bold | green}} {{ trimText .Code.Content | bold}} {{ else }} " +
-			"{{`solution:` | bold | yellow }} {{ trimText .Solution.Content | bold }} {{ end }}",
-		Inactive: "{{ if .Code.Content -}} {{`code:` | green }} {{ trimText .Code.Content }} " +
-			"{{- else -}} {{`solution:` | yellow}} {{ trimText .Solution.Content }} {{ end }}",
-		Selected: " {{ `✓` | green }} {{if .Code.Content -}} {{ .Code.Content | bold }} {{- else -}} {{ .Solution.Content | bold }} {{ end }}",
+			"{{ inline .Code.Content}} {{- else -}} {{ inline .Solution.Content }} {{ end }}",
+		Active: "* {{ if .Code.Content -}} {{`code:` | bold | green}} {{ inline .Code.Content | bold}} {{ else }} " +
+			"{{`solution:` | bold | yellow }} {{ inline .Solution.Content | bold }} {{ end }}",
+		Inactive: "{{ if .Code.Content -}} {{`code:` | green }} {{ inline .Code.Content }} " +
+			"{{- else -}} {{`solution:` | yellow}} {{ inline .Solution.Content }} {{ end }}",
+		Selected: " {{ `✓` | green }} {{if .Code.Content -}} {{ inline .Code.Content | bold }} {{- else -}} {{ inline .Solution.Content | bold }} {{ end }}",
 		Details: "Type: {{- if .Code.Content }} code {{ else }} solution {{- end }}" +
-			"{{ if .Code.Alias }} | Alias: {{ trimText .Code.Alias }} {{- end }}" +
-			"{{ if .Comment }} | Comment: {{ trimText .Comment }} {{- end }}",
+			"{{ if .Code.Alias }} | Alias: {{ .Code.Alias }} {{- end }}" +
+			"{{ if .Comment }} | Comment: {{ .Comment }} {{- end }}",
 		FuncMap: funcMap,
 	}
 }


### PR DESCRIPTION
#### This pull request allows user to add command from path

**Why ?**
Some scripts can't fit in a oneliner and are implemented in bash files. 

**How ?**
The user must specifiy the path to the file containing the script he want to store, using the `--path` flag

**Steps to verify:**
1. Write a multiline script in a `test.sh` file

you can use copy and paste this 👇  in your test.sh file

```sh
#!/bin/sh
hosts="eu.gcr.io gcr.io"
list_container_images() {
	p=$@
	for project in $p; do
		echo "$project: "
		list_container_images $(gcloud container images list --repository=$project 2>/dev/null | tail +2)
		gcloud container images list-tags $project 2>/dev/null | tail +2
		echo ""
	done;
}
for host in $hosts; do
	projects=$(gcloud projects list | tail +2 | awk -v host="$host" '{printf ("%s/%s\n", host, $1)}')
	list_container_images $projects
done;
```
2. Run the command `ckp add code --path test.sh -m 'list every single gcp containers'`

