### PR TITLE
add the `ckp edit` command

### DIFF
--- a/cmd/ckp.go
+++ b/cmd/ckp.go
@@ -21,6 +21,7 @@ func NewCKPCommand(config config.Config) *cobra.Command {
 	ckpCommand.AddCommand(NewPushCommand(config))
 	ckpCommand.AddCommand(NewPullCommand(config))
 	ckpCommand.AddCommand(NewRmCommand(config))
+	ckpCommand.AddCommand(NewEditCommand(config))
 	ckpCommand.AddCommand(NewRunCommand(config))
 	return ckpCommand
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -1,0 +1,223 @@
+package cmd
+
+import (
+	"fmt"
+
+	"os"
+	"time"
+
+	"github.com/elhmn/ckp/internal/config"
+	"github.com/elhmn/ckp/internal/store"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+//NewEditCommand create new cobra command for the edit command
+func NewEditCommand(conf config.Config) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "edit [code_id | solution_id]",
+		Short: "edit code or solution entries from the store",
+		Long: `edit code or solution entries from the store
+
+		example: ckp edit
+		Will prompt an interactive UI that will allow you to search and delete
+		a code or solution entry
+
+		example: ckp edit <entry_id>
+		Will edit the entry corresponding the entry_id
+`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := editCommand(cmd, args, conf); err != nil {
+				fmt.Fprintf(conf.OutWriter, "Error: %s\n", err)
+				return
+			}
+		},
+	}
+
+	command.PersistentFlags().Bool("from-history", false, `list code and solution records from history`)
+	command.PersistentFlags().StringP("comment", "m", "", `ckp edit -m <comment>`)
+	command.PersistentFlags().StringP("alias", "a", "", `ckp edit -a <alias>`)
+	command.PersistentFlags().StringP("code", "c", "", `ckp edit -c <code>`)
+	command.PersistentFlags().StringP("solution", "s", "", `ckp edit -s <solution>`)
+	return command
+}
+
+func editCommand(cmd *cobra.Command, args []string, conf config.Config) error {
+	var entryID string
+	if len(args) >= 1 {
+		entryID = args[0]
+	}
+
+	if err := cmd.Flags().Parse(args); err != nil {
+		return err
+	}
+	flags := cmd.Flags()
+	fromHistory, err := flags.GetBool("from-history")
+	if err != nil {
+		return fmt.Errorf("could not parse `fromHistory` flag: %s", err)
+	}
+
+	//Setup spinner
+	conf.Spin.Start()
+	defer conf.Spin.Stop()
+
+	dir, err := config.GetStoreDirPath(conf)
+	if err != nil {
+		return fmt.Errorf("failed get repository path: %s", err)
+	}
+
+	//Get the store file path
+	var storeFilePath string
+	if !fromHistory {
+		storeFilePath, err = config.GetStoreFilePath(conf)
+		if err != nil {
+			return fmt.Errorf("failed to get the store file path: %s", err)
+		}
+	} else {
+		storeFilePath, err = config.GetHistoryFilePath(conf)
+		if err != nil {
+			return fmt.Errorf("failed to get the history store file path: %s", err)
+		}
+	}
+
+	conf.Spin.Message(" pulling remote changes...")
+	err = pullRemoteChanges(conf, dir, storeFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to pull remote changes: %s", err)
+	}
+	conf.Spin.Message(" remote changes pulled")
+
+	conf.Spin.Message(" removing changes")
+	storeFile, storeData, storeBytes, err := loadStore(storeFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to load the store: %s", err)
+	}
+
+	index, err := getScriptEntryIndex(conf, storeData.Scripts, entryID)
+	if err != nil {
+		return fmt.Errorf("failed to get script `%s` entry index: %s", entryID, err)
+	}
+
+	//Remove script entry
+	storeData.Scripts, err = editScriptEntry(flags, storeData.Scripts, index)
+	if err != nil {
+		return fmt.Errorf("failed to editScriptEntry: %s", err)
+	}
+
+	tempFile, err := createTempFile(conf, storeBytes)
+	if err != nil {
+		return fmt.Errorf("failed to create tempFile: %s", err)
+	}
+
+	//Save storeData in store
+	if err := saveStore(storeData, storeBytes, storeFile, tempFile); err != nil {
+		return fmt.Errorf("failed to save store in %s:  %s", storeFile, err)
+	}
+
+	//Delete the temporary file
+	if err := os.RemoveAll(tempFile); err != nil {
+		return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
+	}
+
+	conf.Spin.Message(" pushing local changes...")
+	err = pushLocalChanges(conf, dir, commitRemoveAction, storeFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to push local changes: %s", err)
+	}
+	conf.Spin.Message(" local changes pushed")
+
+	fmt.Fprintf(conf.OutWriter, "\nYour entry was successfully edited!\n")
+	return nil
+}
+
+func editScriptEntry(flags *pflag.FlagSet, scripts []store.Script, index int) ([]store.Script, error) {
+	script, err := createNewEntry(flags, scripts[index])
+	if err != nil {
+		return scripts, fmt.Errorf("failed to create new script entry: %s", err)
+	}
+
+	return append(scripts[:index], append(scripts[index+1:], script)...), nil
+}
+
+//createNewEntry return a new code Script entry
+func createNewEntry(flags *pflag.FlagSet, script store.Script) (store.Script, error) {
+	timeNow := time.Now()
+
+	//Get alias
+	alias := script.Code.Alias
+	aliasTmp, err := flags.GetString("alias")
+	if err != nil {
+		return store.Script{}, fmt.Errorf("could not parse `alias` flag: %s", err)
+	}
+	if aliasTmp != "" {
+		alias = aliasTmp
+	}
+
+	//Get comment
+	comment := script.Comment
+	commentTmp, err := flags.GetString("comment")
+	if err != nil {
+		return store.Script{}, fmt.Errorf("could not parse `comment` flag: %s", err)
+	}
+	if commentTmp != "" {
+		comment = commentTmp
+	}
+
+	//Get code
+	var code string
+	if script.Code.Content != "" {
+		code = script.Code.Content
+	}
+	codeTmp, err := flags.GetString("code")
+	if err != nil {
+		return store.Script{}, fmt.Errorf("could not parse `code` flag: %s", err)
+	}
+	if codeTmp != "" {
+		code = codeTmp
+	}
+
+	//Get Solution
+	var solution string
+	if script.Solution.Content != "" {
+		solution = script.Solution.Content
+	}
+	solutionTmp, err := flags.GetString("solution")
+	if err != nil {
+		return store.Script{}, fmt.Errorf("could not parse `solution` flag: %s", err)
+	}
+	if solutionTmp != "" {
+		solution = solutionTmp
+	}
+
+	//Generate script entry unique id
+	id, err := store.GenereateIdempotentID(code, comment, alias, solution)
+	if err != nil {
+		return store.Script{}, fmt.Errorf("failed to generate idem potent id: %s", err)
+	}
+
+	if solution != "" {
+		return store.Script{
+			ID:           id,
+			Comment:      comment,
+			CreationTime: timeNow,
+			UpdateTime:   timeNow,
+			Solution: store.Solution{
+				Content: solution,
+			},
+			Code: store.Code{},
+		}, nil
+	}
+
+	return store.Script{
+		ID:           id,
+		Comment:      comment,
+		CreationTime: timeNow,
+		UpdateTime:   timeNow,
+		Code: store.Code{
+			Content: code,
+			Alias:   alias,
+		},
+		Solution: store.Solution{},
+	}, nil
+}

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -1,0 +1,128 @@
+package cmd_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/elhmn/ckp/cmd"
+	"github.com/elhmn/ckp/internal/config"
+	"github.com/elhmn/ckp/internal/store"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEditCommand(t *testing.T) {
+	t.Run("make sure that it runs successfully for code edition", func(t *testing.T) {
+		conf, mockedExec := createConfig(t)
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		if err := setupFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		//Specify expectations
+		gomock.InOrder(
+			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "pull", "--rebase", "origin", "main"),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "add", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "commit", "-m", "ckp: add store"),
+		)
+
+		command := cmd.NewEditCommand(conf)
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		//Set args
+		codeID := "hash-of-file-content"
+		command.SetArgs([]string{codeID,
+			"--code", "a_code",
+			"--comment", "a_comment",
+			"--alias", "an_alias",
+		})
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		got := writer.String()
+		exp := "\nYour entry was successfully edited!\n"
+		assert.Equal(t, exp, got)
+
+		//Test that the store was correctly edited
+		filePath, _ := config.GetStoreFilePath(conf)
+		s, _, err := store.LoadStore(filePath)
+		if err != nil {
+			t.Errorf("Error: failed to load the store with %s", err)
+		}
+		script := s.Scripts[1]
+		assert.Equal(t, "a_code", script.Code.Content)
+		assert.Equal(t, "a_comment", script.Comment)
+		assert.Equal(t, "an_alias", script.Code.Alias)
+
+		//function call assert
+		if err := deleteFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+	})
+
+	t.Run("make sure that it runs successfully for solution edition", func(t *testing.T) {
+		conf, mockedExec := createConfig(t)
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		if err := setupFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		//Specify expectations
+		gomock.InOrder(
+			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "pull", "--rebase", "origin", "main"),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "add", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "commit", "-m", "ckp: add store"),
+		)
+
+		command := cmd.NewEditCommand(conf)
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		//Set args
+		solutionID := "hash-of-file-content-2"
+		command.SetArgs([]string{solutionID,
+			"--solution", "a_solution",
+			"--comment", "a_comment",
+		})
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		got := writer.String()
+		exp := "\nYour entry was successfully edited!\n"
+		assert.Equal(t, exp, got)
+
+		//Test that the store was correctly edited
+		filePath, _ := config.GetStoreFilePath(conf)
+		s, _, err := store.LoadStore(filePath)
+		if err != nil {
+			t.Errorf("Error: failed to load the store with %s", err)
+		}
+		script := s.Scripts[1]
+		assert.Equal(t, "a_solution", script.Solution.Content)
+		assert.Equal(t, "a_comment", script.Comment)
+
+		//function call assert
+		if err := deleteFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+	})
+}


### PR DESCRIPTION
#### This pull request does implements the `ckp edit` command

**Why ?**
We want to be able to edit commands we have saved in our storage

**How ?**
The user provides an ID of the command he wants to edit along with few parameters such comments or aliases, which
will be used to create a new code or solution entry and remove the entry matching the ID sent as parameter.

**Steps to verify:**
1. add a command using `ckp add code -m 'my comment' 'echo my code'`
2. the run `ckp edit <entryID> -m 'my new comment' 'echo my new code'`
3. use `ckp list` to check if a command containing the new fields was added

You can do the same using the `--from-history` flag to edit your history commands