### PR TITLE
Open vim for add command

### DIFF
--- a/cmd/add_code_test.go
+++ b/cmd/add_code_test.go
@@ -108,7 +108,7 @@ func TestAddCodeCommand(t *testing.T) {
 
 		got := writer.String()
 		exp := "\nYour code was successfully added!\n"
-		assert.Equal(t, exp, got)
+		assert.Contains(t, got, exp)
 
 		//function call assert
 		if err := deleteFolder(conf); err != nil {

--- a/cmd/add_code_test.go
+++ b/cmd/add_code_test.go
@@ -115,4 +115,52 @@ func TestAddCodeCommand(t *testing.T) {
 			t.Errorf("Error: failed with %s", err)
 		}
 	})
+
+	t.Run("make sure that it runs successfully without code arguument", func(t *testing.T) {
+		conf := createConfig(t)
+		mockedExec := conf.Exec.(*mocks.MockIExec)
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		if err := setupFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		//Specify expectations
+		gomock.InOrder(
+			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "pull", "--rebase", "origin", "main"),
+			mockedExec.EXPECT().OpenEditor(gomock.Any(), gomock.Any()).Return(nil),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "add", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "commit", "-m", "ckp: add store"),
+		)
+
+		commandName := "code"
+		command := cmd.NewAddCommand(conf)
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		//Set args
+		command.SetArgs([]string{commandName,
+			"--comment", "a_comment",
+			"--alias", "an_alias",
+		})
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		got := writer.String()
+		exp := "\nYour code was successfully added!\n"
+		assert.Contains(t, got, exp)
+
+		//function call assert
+		if err := deleteFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+	})
 }

--- a/cmd/add_solution.go
+++ b/cmd/add_solution.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/briandowns/spinner"
 	"github.com/elhmn/ckp/internal/config"
 	"github.com/elhmn/ckp/internal/printers"
 	"github.com/elhmn/ckp/internal/store"
@@ -56,9 +55,8 @@ func addSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) e
 	}
 
 	//Setup spinner
-	spin := spinner.New(spinner.CharSets[11], 100*time.Millisecond)
-	spin.Start()
-	defer spin.Stop()
+	conf.Spin.Start()
+	defer conf.Spin.Stop()
 
 	dir, err := config.GetStoreDirPath(conf)
 	if err != nil {
@@ -70,14 +68,14 @@ func addSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) e
 		return fmt.Errorf("failed get store file path: %s", err)
 	}
 
-	spin.Suffix = " pulling remote changes..."
+	conf.Spin.Message(" pulling remote changes...")
 	err = pullRemoteChanges(conf, dir, storeFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to pull remote changes: %s", err)
 	}
-	spin.Suffix = " remote changes pulled"
+	conf.Spin.Message(" remote changes pulled")
 
-	spin.Suffix = " adding new solution entry..."
+	conf.Spin.Message(" adding new solution entry...")
 	_, storeData, storeBytes, err := loadStore(storeFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to load the store: %s", err)
@@ -114,14 +112,14 @@ func addSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) e
 	if err := os.RemoveAll(tempFile); err != nil {
 		return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
 	}
-	spin.Suffix = " new entry successfully added"
+	conf.Spin.Message(" new entry successfully added")
 
-	spin.Suffix = " pushing local changes..."
+	conf.Spin.Message(" pushing local changes...")
 	err = pushLocalChanges(conf, dir, commitAddAction, storeFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to push local changes: %s", err)
 	}
-	spin.Suffix = " local changes pushed"
+	conf.Spin.Message(" local changes pushed")
 
 	fmt.Fprintln(conf.OutWriter, "\nYour solution was successfully added!")
 	return nil

--- a/cmd/add_solution_test.go
+++ b/cmd/add_solution_test.go
@@ -50,7 +50,53 @@ func TestAddSolutionCommand(t *testing.T) {
 
 		got := writer.String()
 		exp := "\nYour solution was successfully added!\n"
-		assert.Equal(t, exp, got)
+		assert.Contains(t, got, exp)
+
+		if err := deleteFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+	})
+
+	t.Run("make sure that is runs successfully without solution argument", func(t *testing.T) {
+		conf := createConfig(t)
+		mockedExec := conf.Exec.(*mocks.MockIExec)
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		if err := setupFolder(conf); err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		//Specify expectations
+		gomock.InOrder(
+			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "pull", "--rebase", "origin", "main"),
+			mockedExec.EXPECT().OpenEditor(gomock.Any(), gomock.Any()).Return(nil),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "add", gomock.Any()),
+			mockedExec.EXPECT().DoGit(gomock.Any(), "commit", "-m", "ckp: add store"),
+		)
+
+		commandName := "solution"
+		command := cmd.NewAddCommand(conf)
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		//Set args
+		command.SetArgs([]string{commandName,
+			"--comment", "a_comment",
+		})
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		got := writer.String()
+		exp := "\nYour solution was successfully added!\n"
+		assert.Contains(t, got, exp)
 
 		if err := deleteFolder(conf); err != nil {
 			t.Errorf("Error: failed with %s", err)

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -280,6 +280,8 @@ func getNewEntryDataFromFile(conf config.Config, origEntry store.Script, templat
 	switch templateType {
 	case CodeEntryTemplateType:
 		content = fmt.Sprintf(editorFileCodeTemplate, origEntry.Comment, origEntry.Code.Alias, origEntry.Code.Content)
+	case SolutionEntryTemplateType:
+		content = fmt.Sprintf(editorFileSolutionTemplate, origEntry.Comment, origEntry.Solution.Content)
 	case EntryTemplateType:
 		content = fmt.Sprintf(editorFileTemplate, origEntry.ID, origEntry.Comment, origEntry.Code.Alias, origEntry.Code.Content, origEntry.Solution.Content)
 	}
@@ -328,6 +330,8 @@ func parseDataFromEditorTemplateFile(filepath string, templateType string) (stor
 	switch templateType {
 	case CodeEntryTemplateType:
 		return parseCodeDataFromEditorTemplateString(string(data)), nil
+	case SolutionEntryTemplateType:
+		return parseSolutionDataFromEditorTemplateString(string(data)), nil
 	}
 
 	return parseDataFromEditorTemplateString(string(data)), nil
@@ -394,6 +398,26 @@ func parseCodeDataFromEditorTemplateString(data string) store.Script {
 			Alias:   alias,
 		},
 		Solution: store.Solution{},
+	}
+}
+
+func parseSolutionDataFromEditorTemplateString(data string) store.Script {
+	lines := strings.Split(data, "\n")
+
+	//get comment
+	i := moveToNextEntry(lines, 0)
+	comment, i := getEntry(lines, i)
+
+	//get solution
+	i = moveToNextEntry(lines, i)
+	solution, _ := getEntry(lines, i)
+
+	return store.Script{
+		Comment: comment,
+		Solution: store.Solution{
+			Content: solution,
+		},
+		Code: store.Code{},
 	}
 }
 

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -385,7 +385,7 @@ func parseCodeDataFromEditorTemplateString(data string) store.Script {
 
 	//get code
 	i = moveToNextEntry(lines, i)
-	code, i := getEntry(lines, i)
+	code, _ := getEntry(lines, i)
 
 	return store.Script{
 		Comment: comment,


### PR DESCRIPTION
#### This pull request adds interactive mode for the `ckp add` command

**Why ?**
Adding a new command required the comment, alias, the code or solution to be passed to the CLI as arguments.
It did not make it very easy to add multiline scripts and solutions, that's why we decided to allow user to add code or solutions using a text editor.

**How ?**
The new `ckp add code` and `ckp add solution` command opens `vim` when no code or solution argument is given to 
the CLI. The file content is then parsed and used to create a new code entry.

**Steps to verify:**
1. Run `ckp add code` without argument, edit the correct fields, save the file and run `ckp list --all` to verify that your entry was created 
2. Run `ckp add solution` without argument, edit the correct fields, save the file and run `ckp list --all` to verify that your entry was created
3. Run `ckp add solution --comment 'your comment' `, check if editor is opened with `your comment` set in the comment section, save the file and check if the entry was created
4. Run `ckp add code --comment 'your comment' --alias 'my_alias' `, check if editor is opened with `your comment` and `my_alias` is set in their corresponding sections, save the file and check if the entry was created.
 