### PR TITLE
refactor: change template for the add command

### DIFF
--- a/cmd/add_code.go
+++ b/cmd/add_code.go
@@ -14,26 +14,9 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-const editorFileCodeTemplate = `## You are adding a code entry
-##
-##----------------------------------------------------------------------
-## Add your comment
-##----------------------------------------------------------------------
-
+const editorFileCodeTemplate = `## comment: %s
+## alias: %s
 %s
-
-##----------------------------------------------------------------------
-## Set an alias
-##----------------------------------------------------------------------
-
-%s
-
-##----------------------------------------------------------------------
-## Here goes your code entry
-##----------------------------------------------------------------------
-
-%s
-
 `
 
 //NewAddCodeCommand adds everything that written after --code or --solution flag

--- a/cmd/add_solution.go
+++ b/cmd/add_solution.go
@@ -14,20 +14,8 @@ import (
 	flag "github.com/spf13/pflag"
 )
 
-const editorFileSolutionTemplate = `## You are adding a solution entry
-##
-##----------------------------------------------------------------------
-## Add your comment
-##----------------------------------------------------------------------
-
+const editorFileSolutionTemplate = `## comment: %s
 %s
-
-##----------------------------------------------------------------------
-## Here goes your solution entry
-##----------------------------------------------------------------------
-
-%s
-
 `
 
 //NewAddSolutionCommand adds everything that written after --solution or --solution flag

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -380,16 +380,13 @@ func parseCodeDataFromEditorTemplateString(data string) store.Script {
 	lines := strings.Split(data, "\n")
 
 	//get comment
-	i := moveToNextEntry(lines, 0)
-	comment, i := getEntry(lines, i)
+	comment, _ := getComment(lines)
 
 	//get alias
-	i = moveToNextEntry(lines, i)
-	alias, i := getEntry(lines, i)
+	alias, _ := getAlias(lines)
 
 	//get code
-	i = moveToNextEntry(lines, i)
-	code, _ := getEntry(lines, i)
+	code := getCode(lines)
 
 	return store.Script{
 		Comment: comment,
@@ -405,12 +402,10 @@ func parseSolutionDataFromEditorTemplateString(data string) store.Script {
 	lines := strings.Split(data, "\n")
 
 	//get comment
-	i := moveToNextEntry(lines, 0)
-	comment, i := getEntry(lines, i)
+	comment, _ := getComment(lines)
 
 	//get solution
-	i = moveToNextEntry(lines, i)
-	solution, _ := getEntry(lines, i)
+	solution := getSolution(lines)
 
 	return store.Script{
 		Comment: comment,
@@ -436,6 +431,64 @@ func moveToNextEntry(lines []string, i int) int {
 	}
 
 	return i
+}
+
+//getComment iterate over the file content and returns the first `## comment:` line
+// it returns the comment it found or an error if no comment was founds
+func getComment(lines []string) (string, error) {
+	for _, line := range lines {
+		if strings.Contains(line, "## comment") {
+			s := strings.Split(line, ":")
+			if len(s) >= 2 {
+				return strings.Join(s[1:], ""), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("comment not found")
+}
+
+//getAlias iterate over the file content and returns the first `## alias:` line
+// it returns the alias it found or an error if no alias was founds
+func getAlias(lines []string) (string, error) {
+	for _, line := range lines {
+		if strings.Contains(line, "## alias") {
+			s := strings.Split(line, ":")
+			if len(s) >= 2 {
+				return strings.Join(s[1:], ""), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("alias not found")
+}
+
+//getCode iterate over the file content and returns
+//everything that does not start with "##" as a code
+func getCode(lines []string) string {
+	code := ""
+	for _, line := range lines {
+		//if "##" is at the beginning of the line
+		if strings.Index(line, "##") != 0 {
+			code += line + "\n"
+		}
+	}
+
+	return strings.Trim(code, "\n")
+}
+
+//getSolution iterate over the file content and returns
+//everything that does not start with "##" as a solution
+func getSolution(lines []string) string {
+	solution := ""
+	for _, line := range lines {
+		//if "##" is at the beginning of the line
+		if strings.Index(line, "##") != 0 {
+			solution += line + "\n"
+		}
+	}
+
+	return strings.Trim(solution, "\n")
 }
 
 //getEntry returns the entry and returns an index to the next line


### PR DESCRIPTION
#### This pull request changes the template used to set comment and alias for the `ckp add` command

**Why ?**
The previous template looked a little heavy, thus we have decided to provide a lighter template. 

**How ?**
Changes the template for the `ckp add code` and `ckp add solution` command

**Steps to verify:**
Run the `ckp add code` or `ckp add solution` commands and check if it uses the template defined bellow:

```
## comment: 
## alias: 

```