### PR TITLE
feat: add code edition interactive mode

### DIFF
--- a/cmd/add_code.go
+++ b/cmd/add_code.go
@@ -127,7 +127,7 @@ func addCodeCommand(cmd *cobra.Command, args []string, conf config.Config) error
 			return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
 		}
 
-		return fmt.Errorf("An identical record was found in the storage, please try `ckp edit --id %s`", script.ID)
+		return fmt.Errorf("An identical record was found in the storage, please try `ckp edit %s`", script.ID)
 	}
 
 	//Add new script entry in the `Store` struct

--- a/cmd/add_solution.go
+++ b/cmd/add_solution.go
@@ -121,7 +121,7 @@ func addSolutionCommand(cmd *cobra.Command, args []string, conf config.Config) e
 			return fmt.Errorf("failed to delete file %s: %s", tempFile, err)
 		}
 
-		return fmt.Errorf("An identical record was found in the storage, please try `ckp edit --id %s`", script.ID)
+		return fmt.Errorf("An identical record was found in the storage, please try `ckp edit %s`", script.ID)
 	}
 
 	//Add new script entry in the `Store` struct


### PR DESCRIPTION
#### This pull request implements `--interactive` mode for the `ckp edit` command

**Why ?**
Before when you ran `ckp edit <code_id>` the command was trying to create a new entry without giving you the chance to
set any value. We then decided to add the `--interactive` mode to make it possible to set the value by editing a file.

**How ?**
It adds a `--interactive` flag that will open a code editor with the content of the previous code entry.

**Steps to verify:**
Run `ckp add --interactive <code_you_want_to_edit_id> -m 'new comment'`, vim should be opened with the content of the
entry you want to edit. Save the file and check that your code was added and changed.