### PR TITLE
feat: dont show solutions in the run command list

### DIFF
--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -140,7 +140,7 @@ func editCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 		return fmt.Errorf("failed to load the store: %s", err)
 	}
 
-	index, err := getScriptEntryIndex(conf, storeData.Scripts, entryID)
+	index, err := getScriptEntryIndex(conf, storeData.Scripts, entryID, store.EntryTypeAll)
 	if err != nil {
 		return fmt.Errorf("failed to get script `%s` entry index: %s", entryID, err)
 	}

--- a/cmd/edit_test.go
+++ b/cmd/edit_test.go
@@ -33,7 +33,7 @@ func TestEditCommand(t *testing.T) {
 			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "add", gomock.Any()),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "commit", "-m", "ckp: add store"),
-			mockedPrinters.EXPECT().SelectScriptEntry(gomock.Any()).Return(0, "", nil),
+			mockedPrinters.EXPECT().SelectScriptEntry(gomock.Any(), store.EntryTypeAll).Return(0, "", nil),
 		)
 
 		command := cmd.NewEditCommand(conf)
@@ -94,7 +94,7 @@ func TestEditCommand(t *testing.T) {
 			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "add", gomock.Any()),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "commit", "-m", "ckp: add store"),
-			mockedPrinters.EXPECT().SelectScriptEntry(gomock.Any()).Return(1, "", nil),
+			mockedPrinters.EXPECT().SelectScriptEntry(gomock.Any(), store.EntryTypeAll).Return(1, "", nil),
 		)
 
 		command := cmd.NewEditCommand(conf)
@@ -149,7 +149,7 @@ func TestEditCommand(t *testing.T) {
 			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "pull", "--rebase", "origin", "main"),
-			mockedPrinters.EXPECT().SelectScriptEntry(gomock.Any()).Return(0, "", nil),
+			mockedPrinters.EXPECT().SelectScriptEntry(gomock.Any(), store.EntryTypeAll).Return(0, "", nil),
 			mockedExec.EXPECT().OpenEditor(gomock.Any(), gomock.Any()).Return(nil),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "fetch", "origin", "main"),
 			mockedExec.EXPECT().DoGit(gomock.Any(), "diff", "origin/main", "--", gomock.Any()),

--- a/cmd/find.go
+++ b/cmd/find.go
@@ -63,7 +63,7 @@ func findCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 
 	scripts := storeData.Scripts
 
-	_, result, err := conf.Printers.SelectScriptEntry(scripts)
+	_, result, err := conf.Printers.SelectScriptEntry(scripts, store.EntryTypeAll)
 	if err != nil {
 		return fmt.Errorf("prompt failed %v", err)
 	}

--- a/cmd/find_test.go
+++ b/cmd/find_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/elhmn/ckp/cmd"
+	"github.com/elhmn/ckp/internal/store"
 	"github.com/elhmn/ckp/mocks"
 	"github.com/golang/mock/gomock"
 )
@@ -15,7 +16,7 @@ func TestFindComment(t *testing.T) {
 		mockedPrinters := conf.Printers.(*mocks.MockIPrinters)
 
 		//Specify expectations
-		mockedPrinters.EXPECT().SelectScriptEntry(gomock.Any())
+		mockedPrinters.EXPECT().SelectScriptEntry(gomock.Any(), store.EntryTypeAll)
 
 		//setup temporary folder
 		if err := setupFolder(conf); err != nil {

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -87,7 +87,7 @@ func rmCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 		return fmt.Errorf("failed to load the store: %s", err)
 	}
 
-	index, err := getScriptEntryIndex(conf, storeData.Scripts, entryID)
+	index, err := getScriptEntryIndex(conf, storeData.Scripts, entryID, store.EntryTypeAll)
 	if err != nil {
 		return fmt.Errorf("failed to get script `%s` entry index: %s", entryID, err)
 	}
@@ -125,10 +125,10 @@ func removeScriptEntry(scripts []store.Script, index int) []store.Script {
 	return append(scripts[:index], scripts[index+1:]...)
 }
 
-func getScriptEntryIndex(conf config.Config, scripts []store.Script, entryID string) (int, error) {
+func getScriptEntryIndex(conf config.Config, scripts []store.Script, entryID string, entryType string) (int, error) {
 	if entryID == "" {
 		conf.Spin.Stop()
-		index, _, err := conf.Printers.SelectScriptEntry(scripts)
+		index, _, err := conf.Printers.SelectScriptEntry(scripts, entryType)
 		if err != nil {
 			return index, fmt.Errorf("failed to select entry: %s", err)
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -69,7 +69,7 @@ func runCommand(cmd *cobra.Command, args []string, conf config.Config) error {
 		return fmt.Errorf("failed to load the store: %s", err)
 	}
 
-	index, err := getScriptEntryIndex(conf, storeData.Scripts, entryID)
+	index, err := getScriptEntryIndex(conf, storeData.Scripts, entryID, store.EntryTypeCode)
 	if err != nil {
 		return fmt.Errorf("failed to get script `%s` entry index: %s", entryID, err)
 	}

--- a/internal/printers/printers.go
+++ b/internal/printers/printers.go
@@ -15,7 +15,7 @@ var defaultPrinters = Printers{}
 
 type IPrinters interface {
 	Confirm(message string) bool
-	SelectScriptEntry(scripts []store.Script) (int, string, error)
+	SelectScriptEntry(scripts []store.Script, entryType string) (int, string, error)
 }
 
 type Printers struct{}
@@ -57,15 +57,21 @@ func Confirm(message string) bool {
 	return defaultPrinters.Confirm(message)
 }
 
-func SelectScriptEntry(scripts []store.Script) (int, string, error) {
-	return defaultPrinters.SelectScriptEntry(scripts)
+func SelectScriptEntry(scripts []store.Script, entryType string) (int, string, error) {
+	return defaultPrinters.SelectScriptEntry(scripts, entryType)
 }
 
 //SelectScriptEntry prompt a search
 //returns the selected entry index
-func (p Printers) SelectScriptEntry(scripts []store.Script) (int, string, error) {
+func (p Printers) SelectScriptEntry(scripts []store.Script, entryType string) (int, string, error) {
 	searchScript := func(input string, index int) bool {
 		s := scripts[index]
+		if entryType == store.EntryTypeCode {
+			return s.Code.Content != "" && DoesScriptContain(s, input)
+		} else if entryType == store.EntryTypeSolution {
+			return s.Solution.Content != "" && DoesScriptContain(s, input)
+		}
+
 		return DoesScriptContain(s, input)
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -19,6 +19,12 @@ const (
 `
 )
 
+const (
+	EntryTypeCode     = "code"
+	EntryTypeSolution = "solution"
+	EntryTypeAll      = ""
+)
+
 //Store defines the store.yaml file structure
 type Store struct {
 	Scripts []Script `json:"scripts,omitempty" yaml:"scripts,omitempty"`

--- a/mocks/IPrinters.go
+++ b/mocks/IPrinters.go
@@ -49,9 +49,9 @@ func (mr *MockIPrintersMockRecorder) Confirm(message interface{}) *gomock.Call {
 }
 
 // SelectScriptEntry mocks base method.
-func (m *MockIPrinters) SelectScriptEntry(scripts []store.Script) (int, string, error) {
+func (m *MockIPrinters) SelectScriptEntry(scripts []store.Script, entryType string) (int, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SelectScriptEntry", scripts)
+	ret := m.ctrl.Call(m, "SelectScriptEntry", scripts, entryType)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -59,7 +59,7 @@ func (m *MockIPrinters) SelectScriptEntry(scripts []store.Script) (int, string, 
 }
 
 // SelectScriptEntry indicates an expected call of SelectScriptEntry.
-func (mr *MockIPrintersMockRecorder) SelectScriptEntry(scripts interface{}) *gomock.Call {
+func (mr *MockIPrintersMockRecorder) SelectScriptEntry(scripts, entryType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectScriptEntry", reflect.TypeOf((*MockIPrinters)(nil).SelectScriptEntry), scripts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SelectScriptEntry", reflect.TypeOf((*MockIPrinters)(nil).SelectScriptEntry), scripts, entryType)
 }


### PR DESCRIPTION
#### This pull request prevents solutions from being shown when the `ckp run` command is executed

**Why ?**
The `ckp run` command used to list `solution` entries and we don't want that a solution entry is not supposed to be executed

**How ?**
Prevent solutions entry to be listed on the `ckp run` command output

**Steps to verify:**
1. Run `ckp add solution -m 'my new solution comment' 'my new solution' `
2. Run the `ckp run` command
3. Search for `my solution comment` and verify that the new solution entry is not listed