### PR TITLE
feat: add tag generator workflow

### DIFF
--- a/.github/workflows/generate-tag.yaml
+++ b/.github/workflows/generate-tag.yaml
@@ -1,0 +1,26 @@
+name: Generate tags
+
+on:
+  push:
+    branches:
+      - "master"
+
+jobs:
+  generate-tag-from-semver:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.HOMEBREW_GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install svu
+        run: |
+          echo 'deb [trusted=yes] https://apt.fury.io/caarlos0/ /' | sudo tee /etc/apt/sources.list.d/caarlos0.list
+          sudo apt update
+          sudo apt install svu
+
+      - name: Create next tag
+        run: |
+          tagname=$(svu next); git tag $tagname && git push origin $tagname


### PR DESCRIPTION
#### This pull request add a workflow that use semver to generate a tag

**Why ?**
We would like to generate a release after a pull request is merged

**How ?**
We use [svu](https://github.com/caarlos0/svu) to generate the next ckp tag

**Steps to verify:**
It is not recommended to test it, but you could after this PR is merged check whether it triggers a `generate-tag` workflow that creates and push a new tag. Once the tag is generated the release.yaml workflow should be triggered 