### PR TITLE
feat: add version command

### DIFF
--- a/cmd/ckp.go
+++ b/cmd/ckp.go
@@ -23,5 +23,6 @@ func NewCKPCommand(config config.Config) *cobra.Command {
 	ckpCommand.AddCommand(NewRmCommand(config))
 	ckpCommand.AddCommand(NewEditCommand(config))
 	ckpCommand.AddCommand(NewRunCommand(config))
+	ckpCommand.AddCommand(NewVersionCommand(config))
 	return ckpCommand
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/elhmn/ckp/internal/config"
+	"github.com/spf13/cobra"
+)
+
+//This version will be set by a goreleaser ldflag
+var version = "0.0.0.dev"
+var versionString = `Version: %s
+Build by elhmn
+Support osscameroon here https://opencollective.com/osscameroon
+`
+
+//NewVersionCommand output program version
+func NewVersionCommand(conf config.Config) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "version",
+		Short: "Show ckp version",
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := versionCommand(conf); err != nil {
+				fmt.Fprintf(conf.OutWriter, "Error: %s\n", err)
+				return
+			}
+		},
+	}
+
+	return command
+}
+
+func versionCommand(conf config.Config) error {
+	fmt.Fprintf(conf.OutWriter, versionString, version)
+	return nil
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,32 @@
+package cmd_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/elhmn/ckp/cmd"
+	"github.com/stretchr/testify/assert"
+)
+
+//TestVersionCommand test the `ckp version` command
+func TestVersionCommand(t *testing.T) {
+	t.Run("showed version successfully", func(t *testing.T) {
+		conf := createConfig(t)
+		writer := &bytes.Buffer{}
+		conf.OutWriter = writer
+
+		command := cmd.NewVersionCommand(conf)
+
+		//Set writer
+		command.SetOutput(conf.OutWriter)
+
+		err := command.Execute()
+		if err != nil {
+			t.Errorf("Error: failed with %s", err)
+		}
+
+		got := writer.String()
+		exp := "Version: 0.0.0.dev\nBuild by elhmn\nSupport osscameroon here https://opencollective.com/osscameroon\n"
+		assert.Contains(t, got, exp)
+	})
+}


### PR DESCRIPTION
#### This pull request add `ckp version` command
**Why ?**
We would like to output ckp's version
**How ?**
This implementation uses golang `-ldflags` version set by goreleaser
**Steps to verify:**
build the cli with `make build` and run `./ckp version` the output should be similar to :

``` bash
Version: 0.0.0.dev
Build by elhmn
Support osscameroon here https://opencollective.com/osscameroon
```