### PR TITLE
feat: add concurrency for list

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ jobs:
         uses:
           actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.16.9
         id: go
 
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
         uses:
           actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.16.9
         id: go
 
       - name: Checkout
@@ -35,7 +35,7 @@ jobs:
         uses:
           actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.16.9
         id: go
 
       - name: Checkout
@@ -57,7 +57,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.16.9
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         uses:
           actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.16.9
         id: go
 
       - name: Checkout

--- a/cmd/add_history_test.go
+++ b/cmd/add_history_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/elhmn/ckp/cmd"
@@ -73,12 +74,13 @@ func TestAddHistoryCommand(t *testing.T) {
 		}
 
 		//Delete history tmp files
-		// 		if err := files.DeleteFileFromHomeDirectory(history.BashHistoryFile); err != nil {
-		// 			t.Error(err)
-		// 		}
-		// 		if err := files.DeleteFileFromHomeDirectory(history.ZshHistoryFile); err != nil {
-		// 			t.Error(err)
-		// 		}
+		if err := files.DeleteFileFromHomeDirectory(history.BashHistoryFile); err != nil {
+			fmt.Printf("Failed to remove file: %s\n", err)
+		}
+
+		if err := files.DeleteFileFromHomeDirectory(history.ZshHistoryFile); err != nil {
+			fmt.Printf("Failed to remove file: %s\n", err)
+		}
 
 		//Restore history path
 		history.BashHistoryFile = origBashHistoryFile

--- a/cmd/add_history_test.go
+++ b/cmd/add_history_test.go
@@ -73,12 +73,12 @@ func TestAddHistoryCommand(t *testing.T) {
 		}
 
 		//Delete history tmp files
-		if err := files.DeleteFileFromHomeDirectory(history.BashHistoryFile); err != nil {
-			t.Error(err)
-		}
-		if err := files.DeleteFileFromHomeDirectory(history.ZshHistoryFile); err != nil {
-			t.Error(err)
-		}
+		// 		if err := files.DeleteFileFromHomeDirectory(history.BashHistoryFile); err != nil {
+		// 			t.Error(err)
+		// 		}
+		// 		if err := files.DeleteFileFromHomeDirectory(history.ZshHistoryFile); err != nil {
+		// 			t.Error(err)
+		// 		}
 
 		//Restore history path
 		history.BashHistoryFile = origBashHistoryFile

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -2,9 +2,11 @@ package cmd_test
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/elhmn/ckp/cmd"
+	"github.com/elhmn/ckp/internal/config"
 )
 
 func TestListCommand(t *testing.T) {
@@ -85,4 +87,31 @@ func TestListCommand(t *testing.T) {
 			t.Errorf("Error: failed with %s", err)
 		}
 	})
+}
+
+func BenchmarkListFromHistory(b *testing.B) {
+	conf := config.NewDefaultConfig(config.Options{Version: "0.0.0+dev"})
+	writer := &bytes.Buffer{}
+	conf.OutWriter = writer
+	conf.CKPDir = ".ckp_test"
+
+	if err := setupFolder(conf); err != nil {
+		fmt.Printf("Error: failed with %s", err)
+	}
+
+	command := cmd.NewListCommand(conf)
+	//Set writer
+	command.SetOutput(conf.OutWriter)
+
+	//Set args
+	command.SetArgs([]string{"--all", "--from-history"})
+
+	err := command.Execute()
+	if err != nil {
+		fmt.Printf("Error: failed with %s", err)
+	}
+
+	if err := deleteFolder(conf); err != nil {
+		fmt.Printf("Error: failed with %s", err)
+	}
 }


### PR DESCRIPTION
#### This pull request improves considerably the speed of the list command

**Why ?**
On big files ( > 4mb) the list command was taking almost 50 minutes to run, we wanted to bring it down to a reasonable time. And now it runs bellow 2s

**How ?**
To improve the command speed, the reformat of the file content is now done concurrently.

**Steps to verify:**

To test that it runs now bellow 2s run `time ./ckp f --from-history --all`

**Screenshots (optional)**

#### BEFORE
<img width="681" alt="Screenshot 2021-11-03 at 12 08 49" src="https://user-images.githubusercontent.com/5704817/140050052-9f212490-c631-4ee4-91ab-475b88e0580b.png">

#### AFTER
<img width="673" alt="Screenshot 2021-11-03 at 12 06 26" src="https://user-images.githubusercontent.com/5704817/140049837-2fd9efe6-1bee-4abe-a08e-cf647b2816dd.png">

